### PR TITLE
[Feat] 일정 참여 신청 API 구현

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/PlanServiceApplication.java
+++ b/src/main/java/com/yeoljeong/tripmate/PlanServiceApplication.java
@@ -2,14 +2,10 @@ package com.yeoljeong.tripmate;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
 @EnableDiscoveryClient
-@EntityScan("com.yeoljeong.tripmate.domain.model")
-@EnableJpaRepositories("com.yeoljeong.tripmate")
 public class PlanServiceApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/yeoljeong/tripmate/application/dto/command/ParticipatePlanCommand.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/dto/command/ParticipatePlanCommand.java
@@ -1,0 +1,11 @@
+package com.yeoljeong.tripmate.application.dto.command;
+
+import java.util.UUID;
+
+public record ParticipatePlanCommand(
+    UUID guestId,
+    UUID planId,
+    UUID planUnitId
+) {
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/application/dto/result/ParticipatePlanResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/dto/result/ParticipatePlanResult.java
@@ -1,0 +1,16 @@
+package com.yeoljeong.tripmate.application.dto.result;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ParticipatePlanResult(
+    UUID planParticipantId,
+    String planUnitTitle,
+    LocalDateTime updatedAt,
+    UUID updatedBy
+) {
+
+  public static ParticipatePlanResult from(UUID id, String title, LocalDateTime updatedAt, UUID updatedBy) {
+    return new ParticipatePlanResult(id, title,updatedAt, updatedBy);
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanCommandService.java
@@ -2,7 +2,9 @@ package com.yeoljeong.tripmate.application.service.command;
 
 import com.yeoljeong.tripmate.application.dto.command.CreatePlanCommand;
 import com.yeoljeong.tripmate.application.dto.command.CreatePlanUnitCommand;
+import com.yeoljeong.tripmate.application.dto.command.ParticipatePlanCommand;
 import com.yeoljeong.tripmate.application.dto.result.CreatePlanResult;
+import com.yeoljeong.tripmate.application.dto.result.ParticipatePlanResult;
 import com.yeoljeong.tripmate.domain.exception.PlanErrorCode;
 import com.yeoljeong.tripmate.domain.repository.PlanParticipationRepository;
 import com.yeoljeong.tripmate.domain.repository.PlanRepository;
@@ -15,6 +17,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +31,9 @@ public class PlanCommandService {
   private final PlanUnitRepository planUnitRepository;
   private final PlanParticipationRepository planParticipationRepository;
 
+  /*
+  * 일정 생성(일정, 단위일정, 참여)
+  * */
   public CreatePlanResult createPlans(CreatePlanCommand command) {
 
     List<CreatePlanUnitCommand> requestPlanUnits = command.getPlanUnit();
@@ -76,6 +82,41 @@ public class PlanCommandService {
 
     return CreatePlanResult.from(savedPlan);
 
+  }
+
+  /*
+  * 참여 신청
+  * */
+  public ParticipatePlanResult participatePlanUnit(ParticipatePlanCommand command) {
+
+    PlanUnit planUnit = getPlanUnitInPlan(command.planId(), command.planUnitId());
+
+    // 중복 참여 검증
+    validateDuplicateParticipation(command.planUnitId(),command.guestId());
+
+    PlanParticipation participation = PlanParticipation.createGuest(command.guestId(), planUnit);
+    PlanParticipation savedParticipation = planParticipationRepository.save(participation);
+
+    return ParticipatePlanResult.from(
+        savedParticipation.getId(),
+        savedParticipation.getPlanUnit().getTitle(),
+        savedParticipation.getUpdatedAt(),
+        savedParticipation.getUpdatedBy());
+
+  }
+
+  private void validateDuplicateParticipation(UUID planUnitId, UUID guestId) {
+    if (planParticipationRepository.existsByPlanUnitIdAndUserId(planUnitId, guestId)) {
+      throw new BusinessException(PlanErrorCode.PLAN_PARTICIPANT_ALREADY_EXISTS);
+    }
+  }
+
+  private PlanUnit getPlanUnitInPlan(UUID planId, UUID planUnitId) {
+    if (!planRepository.existsById(planId)) {
+      throw new BusinessException(PlanErrorCode.PLAN_NOT_FOUND);
+    }
+    return planUnitRepository.findByIdAndPlanId(planUnitId, planId)
+        .orElseThrow(() -> new BusinessException(PlanErrorCode.PLAN_UNIT_NOT_FOUND));
   }
 
   private void validateRequestPlanUnits(List<CreatePlanUnitCommand> requestPlanUnits) {
@@ -130,8 +171,9 @@ public class PlanCommandService {
       if (!keys.add(key)) {
         throw new BusinessException(PlanErrorCode.PLAN_UNIT_DUPLICATED_ORDER);
       }
-
-
     }
   }
+
+
+
 }

--- a/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanCommandService.java
@@ -1,4 +1,4 @@
-package com.yeoljeong.tripmate.application;
+package com.yeoljeong.tripmate.application.service.command;
 
 import com.yeoljeong.tripmate.application.dto.command.CreatePlanCommand;
 import com.yeoljeong.tripmate.application.dto.command.CreatePlanUnitCommand;
@@ -22,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class PlanService {
+public class PlanCommandService {
 
   private final PlanRepository planRepository;
   private final PlanUnitRepository planUnitRepository;

--- a/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanCommandService.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -93,15 +94,19 @@ public class PlanCommandService {
 
     // 중복 참여 검증
     validateDuplicateParticipation(command.planUnitId(),command.guestId());
+    try {
+      PlanParticipation participation = PlanParticipation.createGuest(command.guestId(), planUnit);
+      PlanParticipation savedParticipation = planParticipationRepository.save(participation);
 
-    PlanParticipation participation = PlanParticipation.createGuest(command.guestId(), planUnit);
-    PlanParticipation savedParticipation = planParticipationRepository.save(participation);
+      return ParticipatePlanResult.from(
+          savedParticipation.getId(),
+          savedParticipation.getPlanUnit().getTitle(),
+          savedParticipation.getUpdatedAt(),
+          savedParticipation.getUpdatedBy());
+    } catch (DataIntegrityViolationException e) {
+      throw new BusinessException(PlanErrorCode.PLAN_PARTICIPANT_ALREADY_EXISTS);
+    }
 
-    return ParticipatePlanResult.from(
-        savedParticipation.getId(),
-        savedParticipation.getPlanUnit().getTitle(),
-        savedParticipation.getUpdatedAt(),
-        savedParticipation.getUpdatedBy());
 
   }
 

--- a/src/main/java/com/yeoljeong/tripmate/domain/exception/PlanErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/exception/PlanErrorCode.java
@@ -14,6 +14,7 @@ public enum PlanErrorCode implements ErrorCode {
   PLAN_RECRUIT_STATUS_REQUIRED(HttpStatus.BAD_REQUEST, "일정 모집 상태는 필수입니다."),
   PLAN_TYPE_REQUIRED(HttpStatus.BAD_REQUEST, "일정 생성 방식은 필수입니다."),
   PLAN_CREATION_TYPE_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 일정 생성방식 타입입니다." ),
+  PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 일정입니다." ),
 
 
   // plan_unit
@@ -34,6 +35,7 @@ public enum PlanErrorCode implements ErrorCode {
   PLAN_UNIT_DUPLICATED_ORDER(HttpStatus.BAD_REQUEST, "같은 일정에서 일차와 순서가 중복될 수 없습니다." ),
   PLAN_UNIT_TIME_RANGE_OVERLAP(HttpStatus.BAD_REQUEST, "같은 일차의 단위 일정 시간은 겹칠 수 없습니다." ),
   PLAN_UNIT_REQUIRED(HttpStatus.BAD_REQUEST, "일정 생성에 연결될 단위 일정이 필요합니다." ),
+  PLAN_UNIT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 단위 일정입니다."),
 
 
   // plan_product_snapshot
@@ -54,7 +56,8 @@ public enum PlanErrorCode implements ErrorCode {
   PLAN_PARTICIPANT_PLAN_UNIT_REQUIRED(HttpStatus.BAD_REQUEST, "일정 참가에 연결될 단위 일정 정보가 필요합니다."),
   PLAN_PARTICIPANT_USER_REQUIRED(HttpStatus.BAD_REQUEST, "일정 참여자의 사용자 정보는 필수입니다." ),
   PLAN_PARTICIPANT_ROLE_REQUIRED(HttpStatus.BAD_REQUEST, "일정 참여자의 역할 정보는 필수입니다." ),
-  PLAN_PARTICIPANT_STATUS_REQUIRED(HttpStatus.BAD_REQUEST, "일정 참여자의 상태 정보는 필수입니다." );
+  PLAN_PARTICIPANT_STATUS_REQUIRED(HttpStatus.BAD_REQUEST, "일정 참여자의 상태 정보는 필수입니다." ),
+  PLAN_PARTICIPANT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 해당 일정에 참여 신청한 사용자입니다." );
 
 
   private final HttpStatus status;

--- a/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanParticipationRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanParticipationRepository.java
@@ -2,8 +2,13 @@ package com.yeoljeong.tripmate.domain.repository;
 
 import com.yeoljeong.tripmate.domain.model.plan.PlanParticipation;
 import java.util.List;
+import java.util.UUID;
 
 public interface PlanParticipationRepository {
 
   void saveAll(List<PlanParticipation> planParticipation);
+
+  PlanParticipation save(PlanParticipation participation);
+
+  boolean existsByPlanUnitIdAndUserId(UUID planUnitId, UUID guestId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanRepository.java
@@ -1,8 +1,11 @@
 package com.yeoljeong.tripmate.domain.repository;
 
 import com.yeoljeong.tripmate.domain.model.plan.Plan;
+import java.util.UUID;
 
 public interface PlanRepository {
 
   Plan save(Plan plan);
+
+  boolean existsById(UUID planId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanUnitRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanUnitRepository.java
@@ -2,8 +2,12 @@ package com.yeoljeong.tripmate.domain.repository;
 
 import com.yeoljeong.tripmate.domain.model.plan.PlanUnit;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface PlanUnitRepository {
 
   void saveAll(List<PlanUnit> planUnit);
+
+  Optional<PlanUnit> findByIdAndPlanId(UUID planUnitId, UUID planId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/jpa/PlanParticipationJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/jpa/PlanParticipationJpaRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlanParticipationJpaRepository extends JpaRepository<PlanParticipation, UUID> {
 
+  boolean existsByPlanUnitIdAndUserId(UUID planUnitId, UUID guestId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/jpa/PlanUnitJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/jpa/PlanUnitJpaRepository.java
@@ -1,9 +1,11 @@
 package com.yeoljeong.tripmate.infrastructer.persistence.jpa;
 
 import com.yeoljeong.tripmate.domain.model.plan.PlanUnit;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlanUnitJpaRepository extends JpaRepository<PlanUnit, UUID> {
 
+  Optional<PlanUnit> findByIdAndPlanId(UUID planUnitId, UUID planId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanParticipationRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanParticipationRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.yeoljeong.tripmate.domain.model.plan.PlanParticipation;
 import com.yeoljeong.tripmate.domain.repository.PlanParticipationRepository;
 import com.yeoljeong.tripmate.infrastructer.persistence.jpa.PlanParticipationJpaRepository;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -16,5 +17,15 @@ public class PlanParticipationRepositoryImpl implements PlanParticipationReposit
   @Override
   public void saveAll(List<PlanParticipation> planParticipation) {
     jpaRepository.saveAll(planParticipation);
+  }
+
+  @Override
+  public PlanParticipation save(PlanParticipation participation) {
+    return jpaRepository.save(participation);
+  }
+
+  @Override
+  public boolean existsByPlanUnitIdAndUserId(UUID planUnitId, UUID guestId) {
+    return jpaRepository.existsByPlanUnitIdAndUserId(planUnitId, guestId);
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.yeoljeong.tripmate.infrastructer.persistence.repository;
 import com.yeoljeong.tripmate.domain.model.plan.Plan;
 import com.yeoljeong.tripmate.domain.repository.PlanRepository;
 import com.yeoljeong.tripmate.infrastructer.persistence.jpa.PlanJpaRepository;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -15,5 +16,10 @@ public class PlanRepositoryImpl implements PlanRepository {
   @Override
   public Plan save(Plan plan) {
     return jpaRepository.save(plan);
+  }
+
+  @Override
+  public boolean existsById(UUID planId) {
+    return jpaRepository.existsById(planId);
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanUnitRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanUnitRepositoryImpl.java
@@ -4,6 +4,8 @@ import com.yeoljeong.tripmate.domain.model.plan.PlanUnit;
 import com.yeoljeong.tripmate.domain.repository.PlanUnitRepository;
 import com.yeoljeong.tripmate.infrastructer.persistence.jpa.PlanUnitJpaRepository;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -16,5 +18,10 @@ public class PlanUnitRepositoryImpl implements PlanUnitRepository {
   @Override
   public void saveAll(List<PlanUnit> planUnit) {
     jpaRepository.saveAll(planUnit);
+  }
+
+  @Override
+  public Optional<PlanUnit> findByIdAndPlanId(UUID planUnitId, UUID planId) {
+    return jpaRepository.findByIdAndPlanId(planUnitId, planId);
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/presentation/PlanController.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/PlanController.java
@@ -1,14 +1,18 @@
 package com.yeoljeong.tripmate.presentation;
 
+import com.yeoljeong.tripmate.application.dto.command.ParticipatePlanCommand;
+import com.yeoljeong.tripmate.application.dto.result.ParticipatePlanResult;
 import com.yeoljeong.tripmate.application.service.command.PlanCommandService;
 import com.yeoljeong.tripmate.application.dto.result.CreatePlanResult;
 import com.yeoljeong.tripmate.presentation.dto.request.CreatePlanRequest;
 import com.yeoljeong.tripmate.presentation.dto.response.CreatePlanResponse;
+import com.yeoljeong.tripmate.presentation.dto.response.ParticipatePlanResponse;
 import com.yeoljeong.tripmate.response.ApiResponse;
 import com.yeoljeong.tripmate.response.constants.CommonSuccessCode;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -21,15 +25,31 @@ import org.springframework.web.bind.annotation.RestController;
 public class PlanController {
 
   private final PlanCommandService planCommandService;
+
   @PostMapping
   public ApiResponse<CreatePlanResponse> createPlans(
-      @RequestHeader("X-USER_ID") UUID userId,
+      @RequestHeader("X-USER-ID") UUID userId,
       @RequestBody @Valid CreatePlanRequest createPlanRequest) {
 
     CreatePlanResult result = planCommandService.createPlans(createPlanRequest.toCommand(userId));
     CreatePlanResponse response = CreatePlanResponse.from(result);
     return ApiResponse.success(CommonSuccessCode.CREATE, "일정 등록이 되었습니다.", response);
-
   }
+
+
+  @PostMapping("/plans/{planId}/unit-plans/{unitPlanId}/participations")
+  public ApiResponse<ParticipatePlanResponse> participatePlan(
+      @RequestHeader("X-USER-ID") UUID userId,
+      @PathVariable("planId") UUID planId,
+      @PathVariable("unitPlanId") UUID planUnitId) {
+
+    ParticipatePlanResult result =
+        planCommandService.participatePlanUnit(new ParticipatePlanCommand(userId, planId, planUnitId));
+    ParticipatePlanResponse response = ParticipatePlanResponse.from(result);
+
+    return ApiResponse.success(CommonSuccessCode.CREATE, "일정 참여 신청이 완료되었습니다.",
+        response);
+  }
+
 
 }

--- a/src/main/java/com/yeoljeong/tripmate/presentation/PlanController.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/PlanController.java
@@ -1,6 +1,6 @@
 package com.yeoljeong.tripmate.presentation;
 
-import com.yeoljeong.tripmate.application.PlanService;
+import com.yeoljeong.tripmate.application.service.command.PlanCommandService;
 import com.yeoljeong.tripmate.application.dto.result.CreatePlanResult;
 import com.yeoljeong.tripmate.presentation.dto.request.CreatePlanRequest;
 import com.yeoljeong.tripmate.presentation.dto.response.CreatePlanResponse;
@@ -20,13 +20,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class PlanController {
 
-  private final PlanService planService;
+  private final PlanCommandService planCommandService;
   @PostMapping
   public ApiResponse<CreatePlanResponse> createPlans(
       @RequestHeader("X-USER_ID") UUID userId,
       @RequestBody @Valid CreatePlanRequest createPlanRequest) {
 
-    CreatePlanResult result = planService.createPlans(createPlanRequest.toCommand(userId));
+    CreatePlanResult result = planCommandService.createPlans(createPlanRequest.toCommand(userId));
     CreatePlanResponse response = CreatePlanResponse.from(result);
     return ApiResponse.success(CommonSuccessCode.CREATE, "일정 등록이 되었습니다.", response);
 

--- a/src/main/java/com/yeoljeong/tripmate/presentation/PlanController.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/PlanController.java
@@ -37,7 +37,7 @@ public class PlanController {
   }
 
 
-  @PostMapping("/plans/{planId}/unit-plans/{unitPlanId}/participations")
+  @PostMapping("/{planId}/unit-plans/{unitPlanId}/participations")
   public ApiResponse<ParticipatePlanResponse> participatePlan(
       @RequestHeader("X-USER-ID") UUID userId,
       @PathVariable("planId") UUID planId,

--- a/src/main/java/com/yeoljeong/tripmate/presentation/dto/response/ParticipatePlanResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/dto/response/ParticipatePlanResponse.java
@@ -1,0 +1,19 @@
+package com.yeoljeong.tripmate.presentation.dto.response;
+
+import com.yeoljeong.tripmate.application.dto.result.ParticipatePlanResult;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ParticipatePlanResponse(
+    UUID planParticipantId,
+    LocalDateTime updatedAt,
+    UUID updatedBy
+) {
+
+  public static ParticipatePlanResponse from(ParticipatePlanResult result) {
+    return new ParticipatePlanResponse(
+        result.planParticipantId(),
+        result.updatedAt(),
+        result.updatedBy());
+  }
+}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 일정 참여를 위한 Controller, Service, Repository 로직을 구현했습니다.
- 일정 참여 신청은 역할은 `GUEST`, 상태는 `PENDING`으로 저장됩니다.
- 중복 참여를 방지하기 위한 검증을 수행했습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- 일정 참여 신청 서비스 Command 추가했습니다.
- 일정 참여 신청 반환을 위한 Result, Response를 추가했습니다.
- 일정 참여 신청은 역할은 `GUEST`, 상태는 `PENDING`으로 저장됩니다.
- 중복 참여를 방지하기 위한 검증을 수행했습니다.
- 일정 참여 신청 실패 케이스에 대한 에러코드를 추가했습니다.


### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 단위 일정 참여 API 추가 및 참여 요청/응답 타입 도입
  * 참여 처리 로직(중복 검사·저장)과 관련 저장소 조회/존재 확인 기능 추가
  * 참여 성공 응답에 참여자 ID·갱신 정보 포함

* **버그 수정**
  * 사용자 헤더 키를 X-USER_ID → X-USER-ID로 변경
  * 존재하지 않는 일정/단위 일정에 대한 404 응답 및 중복 참여에 대한 명확한 오류 처리 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->