### PR TITLE
feat: 참여 일정 상태 변경 API 구현

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/application/dto/command/UpdateParticipantStatusCommand.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/dto/command/UpdateParticipantStatusCommand.java
@@ -1,0 +1,14 @@
+package com.yeoljeong.tripmate.application.dto.command;
+
+import com.yeoljeong.tripmate.domain.enums.ParticipantStatus;
+import java.util.UUID;
+
+public record UpdateParticipantStatusCommand(
+    UUID userId,
+    UUID planId,
+    UUID planUnitId,
+    UUID participationId,
+    ParticipantStatus status
+) {
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/application/dto/result/UpdateParticipantStatusResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/dto/result/UpdateParticipantStatusResult.java
@@ -1,0 +1,26 @@
+package com.yeoljeong.tripmate.application.dto.result;
+
+import com.yeoljeong.tripmate.domain.enums.ParticipantStatus;
+import com.yeoljeong.tripmate.domain.model.plan.PlanParticipation;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record UpdateParticipantStatusResult(
+    UUID planParticipantId,
+    String title,
+    ParticipantStatus status,
+    LocalDateTime updatedAt,
+    UUID updatedBy
+) {
+
+
+  public static UpdateParticipantStatusResult from(PlanParticipation savedPlanParticipation) {
+    return new UpdateParticipantStatusResult(
+        savedPlanParticipation.getId(),
+        savedPlanParticipation.getPlanUnit().getTitle(),
+        savedPlanParticipation.getParticipantStatus(),
+        savedPlanParticipation.getUpdatedAt(),
+        savedPlanParticipation.getUpdatedBy()
+    );
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanCommandService.java
@@ -3,8 +3,10 @@ package com.yeoljeong.tripmate.application.service.command;
 import com.yeoljeong.tripmate.application.dto.command.CreatePlanCommand;
 import com.yeoljeong.tripmate.application.dto.command.CreatePlanUnitCommand;
 import com.yeoljeong.tripmate.application.dto.command.ParticipatePlanCommand;
+import com.yeoljeong.tripmate.application.dto.command.UpdateParticipantStatusCommand;
 import com.yeoljeong.tripmate.application.dto.result.CreatePlanResult;
 import com.yeoljeong.tripmate.application.dto.result.ParticipatePlanResult;
+import com.yeoljeong.tripmate.application.dto.result.UpdateParticipantStatusResult;
 import com.yeoljeong.tripmate.domain.exception.PlanErrorCode;
 import com.yeoljeong.tripmate.domain.repository.PlanParticipationRepository;
 import com.yeoljeong.tripmate.domain.repository.PlanRepository;
@@ -106,9 +108,34 @@ public class PlanCommandService {
     } catch (DataIntegrityViolationException e) {
       throw new BusinessException(PlanErrorCode.PLAN_PARTICIPANT_ALREADY_EXISTS);
     }
-
-
   }
+
+  /*
+  * 참여 신청 상태 변경
+  * */
+  public UpdateParticipantStatusResult updateParticipantStatus(UpdateParticipantStatusCommand command) {
+    
+    PlanUnit planUnit = getPlanUnitInPlan(command.planId(), command.planUnitId());
+
+    // 요청자가 해당 단위 일정의 역할이 'HOST'인지 검증하기 위한 객체
+    PlanParticipation hostPlanParticipation = planParticipationRepository.findByPlanUnitAndUserId(
+            planUnit, command.userId())
+        .orElseThrow(() -> new BusinessException(PlanErrorCode.PLAN_PARTICIPANT_NOT_FOUND));
+
+    hostPlanParticipation.validateHostOf(planUnit);
+
+
+    // 상태를 변경을 위한 객체
+    PlanParticipation targetPlanParticipation = planParticipationRepository.findByIdAndPlanUnit(
+            command.participationId(),planUnit)
+        .orElseThrow(() -> new BusinessException(PlanErrorCode.PLAN_PARTICIPANT_NOT_FOUND));
+
+    targetPlanParticipation.updatePlanParticipantStatus(command.status());
+
+
+    return UpdateParticipantStatusResult.from(targetPlanParticipation);
+  }
+
 
   private void validateDuplicateParticipation(UUID planUnitId, UUID guestId) {
     if (planParticipationRepository.existsByPlanUnitIdAndUserId(planUnitId, guestId)) {
@@ -178,7 +205,6 @@ public class PlanCommandService {
       }
     }
   }
-
 
 
 }

--- a/src/main/java/com/yeoljeong/tripmate/domain/exception/PlanErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/exception/PlanErrorCode.java
@@ -57,7 +57,10 @@ public enum PlanErrorCode implements ErrorCode {
   PLAN_PARTICIPANT_USER_REQUIRED(HttpStatus.BAD_REQUEST, "일정 참여자의 사용자 정보는 필수입니다." ),
   PLAN_PARTICIPANT_ROLE_REQUIRED(HttpStatus.BAD_REQUEST, "일정 참여자의 역할 정보는 필수입니다." ),
   PLAN_PARTICIPANT_STATUS_REQUIRED(HttpStatus.BAD_REQUEST, "일정 참여자의 상태 정보는 필수입니다." ),
-  PLAN_PARTICIPANT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 해당 일정에 참여 신청한 사용자입니다." );
+  PLAN_PARTICIPANT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 해당 일정에 참여 신청한 사용자입니다." ),
+  PLAN_PARTICIPANT_NOT_HOST(HttpStatus.FORBIDDEN, "해당 일정의 참여 상태 변경은 호스트만 가능합니다." ),
+  PLAN_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 일정 참여 정보가 존재하지 않습니다." ),
+  PLAN_PARTICIPANT_PLAN_UNIT_MISMATCH(HttpStatus.BAD_REQUEST, "해당 단위 일정 정보는 요청한 단위 일정과 일치하지 않습니다.");
 
 
   private final HttpStatus status;

--- a/src/main/java/com/yeoljeong/tripmate/domain/exception/PlanErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/exception/PlanErrorCode.java
@@ -60,7 +60,8 @@ public enum PlanErrorCode implements ErrorCode {
   PLAN_PARTICIPANT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 해당 일정에 참여 신청한 사용자입니다." ),
   PLAN_PARTICIPANT_NOT_HOST(HttpStatus.FORBIDDEN, "해당 일정의 참여 상태 변경은 호스트만 가능합니다." ),
   PLAN_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 일정 참여 정보가 존재하지 않습니다." ),
-  PLAN_PARTICIPANT_PLAN_UNIT_MISMATCH(HttpStatus.BAD_REQUEST, "해당 단위 일정 정보는 요청한 단위 일정과 일치하지 않습니다.");
+  PLAN_PARTICIPANT_PLAN_UNIT_MISMATCH(HttpStatus.BAD_REQUEST, "해당 단위 일정 정보는 요청한 단위 일정과 일치하지 않습니다."),
+  PLAN_PARTICIPANT_STATUS_INVALID(HttpStatus.BAD_REQUEST, "참여 상태는 PENDING에서 APPROVAL 또는 REJECTED로만 변경할 수 있습니다.");
 
 
   private final HttpStatus status;

--- a/src/main/java/com/yeoljeong/tripmate/domain/model/plan/PlanParticipation.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/model/plan/PlanParticipation.java
@@ -81,6 +81,12 @@ public class PlanParticipation extends BaseAuditEntity {
     if (status == null) {
       throw new BusinessException(PlanErrorCode.PLAN_PARTICIPANT_STATUS_REQUIRED);
     }
+    if (this.participantStatus != ParticipantStatus.PENDING) {
+      throw new BusinessException(PlanErrorCode.PLAN_PARTICIPANT_STATUS_INVALID);
+    }
+    if (status != ParticipantStatus.APPROVAL && status != ParticipantStatus.REJECTED) {
+      throw new BusinessException(PlanErrorCode.PLAN_PARTICIPANT_STATUS_INVALID);
+    }
     this.participantStatus = status;
   }
 

--- a/src/main/java/com/yeoljeong/tripmate/domain/model/plan/PlanParticipation.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/model/plan/PlanParticipation.java
@@ -74,6 +74,28 @@ public class PlanParticipation extends BaseAuditEntity {
     this.planUnit = planUnit;
   }
 
+  /*
+  * 일정 참여상태 변경
+  * */
+  public void updatePlanParticipantStatus(ParticipantStatus status) {
+    if (status == null) {
+      throw new BusinessException(PlanErrorCode.PLAN_PARTICIPANT_STATUS_REQUIRED);
+    }
+    this.participantStatus = status;
+  }
+
+  public void validateHostOf(PlanUnit planUnit) {
+
+    if (!this.planUnit.equals(planUnit)) {
+      throw new BusinessException(PlanErrorCode.PLAN_PARTICIPANT_PLAN_UNIT_MISMATCH);
+    }
+
+    // host 검증
+    if (!this.participantRole.equals(ParticipantRole.HOST)) {
+      throw new BusinessException(PlanErrorCode.PLAN_PARTICIPANT_NOT_HOST);
+    }
+  }
+
   private void validateParticipantStatus(ParticipantStatus participantStatus) {
     if (participantStatus == null) {
       throw new BusinessException(PlanErrorCode.PLAN_PARTICIPANT_STATUS_REQUIRED);
@@ -98,5 +120,6 @@ public class PlanParticipation extends BaseAuditEntity {
       throw new BusinessException(PlanErrorCode.PLAN_PARTICIPANT_PLAN_UNIT_REQUIRED);
     }
   }
+
 
 }

--- a/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanParticipationRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanParticipationRepository.java
@@ -1,7 +1,9 @@
 package com.yeoljeong.tripmate.domain.repository;
 
 import com.yeoljeong.tripmate.domain.model.plan.PlanParticipation;
+import com.yeoljeong.tripmate.domain.model.plan.PlanUnit;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface PlanParticipationRepository {
@@ -11,4 +13,8 @@ public interface PlanParticipationRepository {
   PlanParticipation save(PlanParticipation participation);
 
   boolean existsByPlanUnitIdAndUserId(UUID planUnitId, UUID guestId);
+
+  Optional<PlanParticipation> findByPlanUnitAndUserId(PlanUnit planUnit, UUID uuid);
+
+  Optional<PlanParticipation> findByIdAndPlanUnit(UUID uuid, PlanUnit planUnit);
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/jpa/PlanParticipationJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/jpa/PlanParticipationJpaRepository.java
@@ -1,10 +1,16 @@
 package com.yeoljeong.tripmate.infrastructer.persistence.jpa;
 
 import com.yeoljeong.tripmate.domain.model.plan.PlanParticipation;
+import com.yeoljeong.tripmate.domain.model.plan.PlanUnit;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlanParticipationJpaRepository extends JpaRepository<PlanParticipation, UUID> {
 
   boolean existsByPlanUnitIdAndUserId(UUID planUnitId, UUID guestId);
+
+  Optional<PlanParticipation> findByPlanUnitAndUserId(PlanUnit planUnit, UUID userId);
+
+  Optional<PlanParticipation> findByIdAndPlanUnit(UUID participationId, PlanUnit planUnit);
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanParticipationRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanParticipationRepositoryImpl.java
@@ -1,9 +1,11 @@
 package com.yeoljeong.tripmate.infrastructer.persistence.repository;
 
 import com.yeoljeong.tripmate.domain.model.plan.PlanParticipation;
+import com.yeoljeong.tripmate.domain.model.plan.PlanUnit;
 import com.yeoljeong.tripmate.domain.repository.PlanParticipationRepository;
 import com.yeoljeong.tripmate.infrastructer.persistence.jpa.PlanParticipationJpaRepository;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -27,5 +29,15 @@ public class PlanParticipationRepositoryImpl implements PlanParticipationReposit
   @Override
   public boolean existsByPlanUnitIdAndUserId(UUID planUnitId, UUID guestId) {
     return jpaRepository.existsByPlanUnitIdAndUserId(planUnitId, guestId);
+  }
+
+  @Override
+  public Optional<PlanParticipation> findByPlanUnitAndUserId(PlanUnit planUnit, UUID userId) {
+    return jpaRepository.findByPlanUnitAndUserId(planUnit, userId);
+  }
+
+  @Override
+  public Optional<PlanParticipation> findByIdAndPlanUnit(UUID participationId, PlanUnit planUnit) {
+    return jpaRepository.findByIdAndPlanUnit(participationId, planUnit);
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/presentation/PlanController.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/PlanController.java
@@ -2,16 +2,20 @@ package com.yeoljeong.tripmate.presentation;
 
 import com.yeoljeong.tripmate.application.dto.command.ParticipatePlanCommand;
 import com.yeoljeong.tripmate.application.dto.result.ParticipatePlanResult;
+import com.yeoljeong.tripmate.application.dto.result.UpdateParticipantStatusResult;
 import com.yeoljeong.tripmate.application.service.command.PlanCommandService;
 import com.yeoljeong.tripmate.application.dto.result.CreatePlanResult;
 import com.yeoljeong.tripmate.presentation.dto.request.CreatePlanRequest;
+import com.yeoljeong.tripmate.presentation.dto.request.UpdateParticipantStatusRequest;
 import com.yeoljeong.tripmate.presentation.dto.response.CreatePlanResponse;
 import com.yeoljeong.tripmate.presentation.dto.response.ParticipatePlanResponse;
+import com.yeoljeong.tripmate.presentation.dto.response.UpdateParticipantStatusResponse;
 import com.yeoljeong.tripmate.response.ApiResponse;
 import com.yeoljeong.tripmate.response.constants.CommonSuccessCode;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -49,6 +53,24 @@ public class PlanController {
 
     return ApiResponse.success(CommonSuccessCode.CREATE, "일정 참여 신청이 완료되었습니다.",
         response);
+  }
+
+  @PatchMapping("/{planId}/unit-plans/{unitPlanId}/participations/{participationId}/status")
+  public ApiResponse<UpdateParticipantStatusResponse> updateParticipantStatus(
+      @RequestHeader("X-USER-ID") UUID userId,
+      @PathVariable("planId") UUID planId,
+      @PathVariable("unitPlanId") UUID planUnitId,
+      @PathVariable("participationId") UUID participationId,
+      @RequestBody @Valid UpdateParticipantStatusRequest request) {
+
+    UpdateParticipantStatusResult result =
+        planCommandService.updateParticipantStatus(
+            request.toCommand(userId, planId, planUnitId, participationId));
+
+    UpdateParticipantStatusResponse response = UpdateParticipantStatusResponse.from(result);
+
+    return ApiResponse.success(CommonSuccessCode.OK, "일정 참여 상태가 변경되었습니다.", response);
+
   }
 
 

--- a/src/main/java/com/yeoljeong/tripmate/presentation/dto/request/UpdateParticipantStatusRequest.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/dto/request/UpdateParticipantStatusRequest.java
@@ -1,0 +1,20 @@
+package com.yeoljeong.tripmate.presentation.dto.request;
+
+import com.yeoljeong.tripmate.application.dto.command.UpdateParticipantStatusCommand;
+import com.yeoljeong.tripmate.domain.enums.ParticipantStatus;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record UpdateParticipantStatusRequest(
+    @NotNull ParticipantStatus status
+) {
+
+  public UpdateParticipantStatusCommand toCommand(
+      UUID userId,
+      UUID planId,
+      UUID planUnitId,
+      UUID participationId
+      ) {
+    return new UpdateParticipantStatusCommand(userId, planId, planUnitId, participationId, status);
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/presentation/dto/response/UpdateParticipantStatusResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/dto/response/UpdateParticipantStatusResponse.java
@@ -1,0 +1,24 @@
+package com.yeoljeong.tripmate.presentation.dto.response;
+
+import com.yeoljeong.tripmate.application.dto.result.UpdateParticipantStatusResult;
+import com.yeoljeong.tripmate.domain.enums.ParticipantStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record UpdateParticipantStatusResponse(
+    UUID planParticipantId,
+    String title,
+    ParticipantStatus status,
+    LocalDateTime updatedAt,
+    UUID updatedBy
+) {
+
+  public static UpdateParticipantStatusResponse from(UpdateParticipantStatusResult result) {
+    return new UpdateParticipantStatusResponse(
+        result.planParticipantId(),
+        result.title(),
+        result.status(),
+        result.updatedAt(),
+        result.updatedBy());
+  }
+}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- close #9 
- 해당 단위일정의 호스트인 사용자만 참여 일정 상태를 변경할 수 있습니다.
- 상태 변경은 (APPROVAL, REJECTED)로 변경이 가능합니다.
### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- 참여 상태 변경을 위한 controller, service, repository 추가
- 요청을 위한 (request, command) ,응답을 위한 (result, response) dto 생성

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 호스트가 참여자의 상태를 변경할 수 있는 기능(PATCH 엔드포인트)이 추가되었습니다. 변경된 참여자 정보, 변경 시간 및 변경자 ID가 응답으로 반환됩니다.

* **버그 수정 / 개선**
  * 상태 변경 시 유효성 검사가 강화되어 허용되지 않는 전환이나 권한 없는 요청에 대해 적절한 오류 응답을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->