### PR TITLE
[Feat] 일정 참여 확인 API 구현 (주문 조회용)

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/application/dto/command/FindParticipantStatusCommand.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/dto/command/FindParticipantStatusCommand.java
@@ -1,0 +1,9 @@
+package com.yeoljeong.tripmate.application.dto.command;
+
+import java.util.UUID;
+
+public record FindParticipantStatusCommand(
+    UUID planUnitId,
+    UUID userId) {
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/application/dto/result/FindParticipationStatusResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/dto/result/FindParticipationStatusResult.java
@@ -1,0 +1,12 @@
+package com.yeoljeong.tripmate.application.dto.result;
+
+import com.yeoljeong.tripmate.domain.enums.ParticipationStatus;
+import java.util.UUID;
+
+public record FindParticipationStatusResult(
+    UUID planUnitId,
+    UUID userId,
+    ParticipationStatus status
+) {
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanInternalCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanInternalCommandService.java
@@ -1,0 +1,24 @@
+package com.yeoljeong.tripmate.application.service.command;
+
+import com.yeoljeong.tripmate.application.dto.command.FindParticipantStatusCommand;
+import com.yeoljeong.tripmate.application.dto.result.FindParticipationStatusResult;
+import com.yeoljeong.tripmate.domain.model.plan.PlanParticipation;
+import com.yeoljeong.tripmate.domain.repository.PlanParticipationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PlanInternalCommandService {
+
+  private final PlanParticipationRepository planParticipationRepository;
+
+  public FindParticipationStatusResult findParticipationStatusByPlanUnitIdAndUserId(
+      FindParticipantStatusCommand command) {
+
+    PlanParticipation participation = planParticipationRepository.findByPlanUnit_IdAndUserId(command.planUnitId(), command.userId());
+
+    return new FindParticipationStatusResult(command.planUnitId(), command.userId(),
+        participation.getParticipationStatus());
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanInternalCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanInternalCommandService.java
@@ -2,8 +2,10 @@ package com.yeoljeong.tripmate.application.service.command;
 
 import com.yeoljeong.tripmate.application.dto.command.FindParticipantStatusCommand;
 import com.yeoljeong.tripmate.application.dto.result.FindParticipationStatusResult;
+import com.yeoljeong.tripmate.domain.exception.PlanErrorCode;
 import com.yeoljeong.tripmate.domain.model.plan.PlanParticipation;
 import com.yeoljeong.tripmate.domain.repository.PlanParticipationRepository;
+import com.yeoljeong.tripmate.exception.BusinessException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,7 +20,8 @@ public class PlanInternalCommandService {
 
   public FindParticipationStatusResult findParticipationStatusByPlanUnitIdAndUserId(UUID planUnitId, UUID userId) {
 
-    PlanParticipation participation = planParticipationRepository.findByPlanUnit_IdAndUserId(planUnitId, userId);
+    PlanParticipation participation = planParticipationRepository.findByPlanUnit_IdAndUserId(planUnitId, userId)
+        .orElseThrow(() -> new BusinessException(PlanErrorCode.PLAN_PARTICIPATION_NOT_FOUND));
 
     return new FindParticipationStatusResult(planUnitId, userId,
         participation.getParticipationStatus());

--- a/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanInternalCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanInternalCommandService.java
@@ -4,21 +4,24 @@ import com.yeoljeong.tripmate.application.dto.command.FindParticipantStatusComma
 import com.yeoljeong.tripmate.application.dto.result.FindParticipationStatusResult;
 import com.yeoljeong.tripmate.domain.model.plan.PlanParticipation;
 import com.yeoljeong.tripmate.domain.repository.PlanParticipationRepository;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class PlanInternalCommandService {
 
   private final PlanParticipationRepository planParticipationRepository;
 
-  public FindParticipationStatusResult findParticipationStatusByPlanUnitIdAndUserId(
-      FindParticipantStatusCommand command) {
+  public FindParticipationStatusResult findParticipationStatusByPlanUnitIdAndUserId(UUID planUnitId, UUID userId) {
 
-    PlanParticipation participation = planParticipationRepository.findByPlanUnit_IdAndUserId(command.planUnitId(), command.userId());
+    PlanParticipation participation = planParticipationRepository.findByPlanUnit_IdAndUserId(planUnitId, userId);
 
-    return new FindParticipationStatusResult(command.planUnitId(), command.userId(),
+    return new FindParticipationStatusResult(planUnitId, userId,
         participation.getParticipationStatus());
   }
+
 }

--- a/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanParticipationRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanParticipationRepository.java
@@ -19,5 +19,5 @@ public interface PlanParticipationRepository {
 
   Optional<PlanParticipation> findByIdAndPlanUnit(UUID uuid, PlanUnit planUnit);
 
-  PlanParticipation findByPlanUnit_IdAndUserId(@NotNull UUID uuid, @NotNull UUID uuid1);
+  Optional<PlanParticipation> findByPlanUnit_IdAndUserId(UUID planUnitId, UUID userId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanParticipationRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanParticipationRepository.java
@@ -2,6 +2,7 @@ package com.yeoljeong.tripmate.domain.repository;
 
 import com.yeoljeong.tripmate.domain.model.plan.PlanParticipation;
 import com.yeoljeong.tripmate.domain.model.plan.PlanUnit;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -17,4 +18,6 @@ public interface PlanParticipationRepository {
   Optional<PlanParticipation> findByPlanUnitAndUserId(PlanUnit planUnit, UUID uuid);
 
   Optional<PlanParticipation> findByIdAndPlanUnit(UUID uuid, PlanUnit planUnit);
+
+  PlanParticipation findByPlanUnit_IdAndUserId(@NotNull UUID uuid, @NotNull UUID uuid1);
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/jpa/PlanParticipationJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/jpa/PlanParticipationJpaRepository.java
@@ -13,4 +13,6 @@ public interface PlanParticipationJpaRepository extends JpaRepository<PlanPartic
   Optional<PlanParticipation> findByPlanUnitAndUserId(PlanUnit planUnit, UUID userId);
 
   Optional<PlanParticipation> findByIdAndPlanUnit(UUID participationId, PlanUnit planUnit);
+
+  PlanParticipation findByPlanUnit_IdAndUserId(UUID planUnitId, UUID userId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanParticipationRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanParticipationRepositoryImpl.java
@@ -40,4 +40,9 @@ public class PlanParticipationRepositoryImpl implements PlanParticipationReposit
   public Optional<PlanParticipation> findByIdAndPlanUnit(UUID participationId, PlanUnit planUnit) {
     return jpaRepository.findByIdAndPlanUnit(participationId, planUnit);
   }
+
+  @Override
+  public PlanParticipation findByPlanUnit_IdAndUserId(UUID planUnitId, UUID userId) {
+    return jpaRepository.findByPlanUnit_IdAndUserId(planUnitId, userId);
+  }
 }

--- a/src/main/java/com/yeoljeong/tripmate/presentation/PlanController.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/PlanController.java
@@ -32,7 +32,7 @@ public class PlanController {
 
   @PostMapping
   public ApiResponse<CreatePlanResponse> createPlans(
-      @RequestHeader("X-USER-ID") UUID userId,
+      @RequestHeader("X-User-Id") UUID userId,
       @RequestBody @Valid CreatePlanRequest createPlanRequest) {
 
     CreatePlanResult result = planCommandService.createPlans(createPlanRequest.toCommand(userId));
@@ -43,7 +43,7 @@ public class PlanController {
 
   @PostMapping("/{planId}/unit-plans/{unitPlanId}/participations")
   public ApiResponse<ParticipatePlanResponse> participatePlan(
-      @RequestHeader("X-USER-ID") UUID userId,
+      @RequestHeader("X-User-Id") UUID userId,
       @PathVariable("planId") UUID planId,
       @PathVariable("unitPlanId") UUID planUnitId) {
 
@@ -57,7 +57,7 @@ public class PlanController {
 
   @PatchMapping("/{planId}/unit-plans/{unitPlanId}/participations/{participationId}/status")
   public ApiResponse<UpdateParticipationStatusResponse> updateParticipationStatus(
-      @RequestHeader("X-USER-ID") UUID userId,
+      @RequestHeader("X-User-Id") UUID userId,
       @PathVariable("planId") UUID planId,
       @PathVariable("unitPlanId") UUID planUnitId,
       @PathVariable("participationId") UUID participationId,

--- a/src/main/java/com/yeoljeong/tripmate/presentation/PlanInternalController.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/PlanInternalController.java
@@ -1,0 +1,36 @@
+package com.yeoljeong.tripmate.presentation;
+
+import com.yeoljeong.tripmate.application.dto.result.FindParticipationStatusResult;
+import com.yeoljeong.tripmate.application.service.command.PlanInternalCommandService;
+import com.yeoljeong.tripmate.application.dto.command.FindParticipantStatusCommand;
+import com.yeoljeong.tripmate.presentation.dto.response.FindParticipationStatusResponse;
+import com.yeoljeong.tripmate.response.ApiResponse;
+import com.yeoljeong.tripmate.response.constants.CommonSuccessCode;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal")
+@RequiredArgsConstructor
+public class PlanInternalController {
+
+  private final PlanInternalCommandService planInternalCommandService;
+
+  @GetMapping("/plan-units/{planUnitId}/participations/users/{userId}")
+  public ApiResponse<FindParticipationStatusResponse> findParticipationStatus(
+      @PathVariable("planUnitId") UUID planUnitId,
+      @PathVariable("userId") UUID userId
+  ) {
+    FindParticipationStatusResult result = planInternalCommandService.findParticipationStatusByPlanUnitIdAndUserId(
+        new FindParticipantStatusCommand(planUnitId, userId));
+
+    FindParticipationStatusResponse response = FindParticipationStatusResponse.from(result);
+
+    return ApiResponse.success(CommonSuccessCode.OK, response);
+  }
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/presentation/PlanInternalController.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/PlanInternalController.java
@@ -25,8 +25,7 @@ public class PlanInternalController {
       @PathVariable("planUnitId") UUID planUnitId,
       @PathVariable("userId") UUID userId
   ) {
-    FindParticipationStatusResult result = planInternalCommandService.findParticipationStatusByPlanUnitIdAndUserId(
-        new FindParticipantStatusCommand(planUnitId, userId));
+    FindParticipationStatusResult result = planInternalCommandService.findParticipationStatusByPlanUnitIdAndUserId(planUnitId, userId);
 
     FindParticipationStatusResponse response = FindParticipationStatusResponse.from(result);
 

--- a/src/main/java/com/yeoljeong/tripmate/presentation/dto/response/FindParticipationStatusResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/dto/response/FindParticipationStatusResponse.java
@@ -1,0 +1,17 @@
+package com.yeoljeong.tripmate.presentation.dto.response;
+
+import com.yeoljeong.tripmate.application.dto.result.FindParticipationStatusResult;
+import com.yeoljeong.tripmate.domain.enums.ParticipationStatus;
+import java.util.UUID;
+
+public record FindParticipationStatusResponse(
+    UUID planUnitId,
+    UUID userId,
+    ParticipationStatus status
+) {
+
+  public static FindParticipationStatusResponse from(FindParticipationStatusResult result) {
+    return new FindParticipationStatusResponse(result.planUnitId(), result.userId(),
+        result.status());
+  }
+}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- close #15 
- 데이터는 다음과 같이 planUnitId, userId, status 로 반환
<img width="424" height="96" alt="image" src="https://github.com/user-attachments/assets/cff41442-371b-4774-b558-0b6389ba554b" />

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- 요청헤더 `X-USER-ID` -> `X-User-Id`
- 내부 일정 참여 확인을 위한 controller, service, repository 구현
-  응답을 위한 result, response 구현 
- 

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 계획 단위별 사용자 참여 상태를 조회하는 내부 API 엔드포인트 추가
  * 참여 상태 조회를 위한 응답 포맷 및 내부 조회 서비스 추가

* **개선 사항**
  * 사용자 식별 헤더 이름 표준화 (`X-USER-ID` → `X-User-Id`)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->