### PR TITLE
[Feat] 주문 생성 이벤트 소비 로직 구현

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanInternalCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanInternalCommandService.java
@@ -32,6 +32,8 @@ public class PlanInternalCommandService {
 
   public void addPlanUnitParticipant(OrderCreatedEvent event) {
 
+    // todo: 동시에 read 한다면 업데이트 유실이 발생할 수 있음.
+    //  -> 낙관적 락(+재시도) or 비관적 락 or 원자 update 쿼리 보호 필요
     PlanUnit planUnit = planUnitRepository.findById(event.planUnitId())
             .orElseThrow(() -> new BusinessException(PlanErrorCode.PLAN_UNIT_NOT_FOUND));
 

--- a/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanInternalCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanInternalCommandService.java
@@ -1,10 +1,12 @@
 package com.yeoljeong.tripmate.application.service.command;
 
-import com.yeoljeong.tripmate.application.dto.command.FindParticipantStatusCommand;
 import com.yeoljeong.tripmate.application.dto.result.FindParticipationStatusResult;
 import com.yeoljeong.tripmate.domain.exception.PlanErrorCode;
 import com.yeoljeong.tripmate.domain.model.plan.PlanParticipation;
+import com.yeoljeong.tripmate.domain.model.plan.PlanUnit;
 import com.yeoljeong.tripmate.domain.repository.PlanParticipationRepository;
+import com.yeoljeong.tripmate.domain.repository.PlanUnitRepository;
+import com.yeoljeong.tripmate.event.OrderCreatedEvent;
 import com.yeoljeong.tripmate.exception.BusinessException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PlanInternalCommandService {
 
   private final PlanParticipationRepository planParticipationRepository;
+  private final PlanUnitRepository planUnitRepository;
 
   public FindParticipationStatusResult findParticipationStatusByPlanUnitIdAndUserId(UUID planUnitId, UUID userId) {
 
@@ -27,4 +30,11 @@ public class PlanInternalCommandService {
         participation.getParticipationStatus());
   }
 
+  public void addPlanUnitParticipant(OrderCreatedEvent event) {
+
+    PlanUnit planUnit = planUnitRepository.findById(event.planUnitId())
+            .orElseThrow(() -> new BusinessException(PlanErrorCode.PLAN_UNIT_NOT_FOUND));
+
+    planUnit.addPlanUnitParticipant(event.quantity());
+  }
 }

--- a/src/main/java/com/yeoljeong/tripmate/domain/exception/PlanErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/exception/PlanErrorCode.java
@@ -63,7 +63,8 @@ public enum PlanErrorCode implements ErrorCode {
   PLAN_PARTICIPATION_NOT_HOST(HttpStatus.FORBIDDEN, "해당 일정의 참여 상태 변경은 호스트만 가능합니다." ),
   PLAN_PARTICIPATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 일정 참여 정보가 존재하지 않습니다." ),
   PLAN_PARTICIPATION_PLAN_UNIT_MISMATCH(HttpStatus.BAD_REQUEST, "해당 단위 일정 정보는 요청한 단위 일정과 일치하지 않습니다."),
-  PLAN_PARTICIPATION_STATUS_INVALID(HttpStatus.BAD_REQUEST, "참여 상태는 PENDING에서 APPROVAL 또는 REJECTED로만 변경할 수 있습니다.");
+  PLAN_PARTICIPATION_STATUS_INVALID(HttpStatus.BAD_REQUEST, "참여 상태는 PENDING에서 APPROVAL 또는 REJECTED로만 변경할 수 있습니다."),
+  PLAN_UNIT_PARTICIPANT_UPDATE_QUANTITY_INVALID(HttpStatus.BAD_REQUEST, "변경할 참여 인원 수가 올바르지 않습니다.");
 
 
   private final HttpStatus status;

--- a/src/main/java/com/yeoljeong/tripmate/domain/model/plan/ParticipantCount.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/model/plan/ParticipantCount.java
@@ -42,6 +42,16 @@ public class ParticipantCount {
     this.currentCount = currentCount;
   }
 
+  // 일정 참여 인원 증가
+  public ParticipantCount add(int quantity) {
+    int newCurrentCount = this.currentCount + quantity;
+
+    if (newCurrentCount > this.maxCount) {
+      throw new BusinessException(PlanErrorCode.PLAN_UNIT_PARTICIPANT_EXCEED);
+    }
+    return new ParticipantCount(this.maxCount, newCurrentCount);
+  }
+
   private void validateNotExceed(int maxCount, int currentCount) {
     if (currentCount > maxCount) {
       throw new BusinessException(PlanErrorCode.PLAN_UNIT_PARTICIPANT_EXCEED);

--- a/src/main/java/com/yeoljeong/tripmate/domain/model/plan/PlanUnit.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/model/plan/PlanUnit.java
@@ -122,6 +122,11 @@ public class PlanUnit extends BaseAuditEntity {
     this.isConfirmed = true;
   }
 
+  /* 일정 현재 인원 증가*/
+  public void addPlanUnitParticipant(int quantity) {
+    this.participantCount = participantCount.add(quantity);
+  }
+
   private void validateOrderIndex(int orderIndex) {
     if (orderIndex < 1) {
       throw new BusinessException(PlanErrorCode.PLAN_UNIT_ORDER_INVALID);
@@ -177,6 +182,5 @@ public class PlanUnit extends BaseAuditEntity {
       throw new BusinessException(PlanErrorCode.PLAN_UNIT_TITLE_EXCEED);
     }
   }
-
 
 }

--- a/src/main/java/com/yeoljeong/tripmate/domain/model/plan/PlanUnit.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/model/plan/PlanUnit.java
@@ -124,7 +124,14 @@ public class PlanUnit extends BaseAuditEntity {
 
   /* 일정 현재 인원 증가*/
   public void addPlanUnitParticipant(int quantity) {
+    validatePositive(quantity);
     this.participantCount = participantCount.add(quantity);
+  }
+
+  private void validatePositive(int quantity) {
+    if (quantity < 1) {
+      throw new BusinessException(PlanErrorCode.PLAN_UNIT_PARTICIPANT_UPDATE_QUANTITY_INVALID);
+    }
   }
 
   private void validateOrderIndex(int orderIndex) {

--- a/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanUnitRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanUnitRepository.java
@@ -10,4 +10,6 @@ public interface PlanUnitRepository {
   void saveAll(List<PlanUnit> planUnit);
 
   Optional<PlanUnit> findByIdAndPlanId(UUID planUnitId, UUID planId);
+
+  Optional<PlanUnit> findById(UUID uuid);
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/external/events/listener/OrderCreatedEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/external/events/listener/OrderCreatedEventListener.java
@@ -1,0 +1,35 @@
+package com.yeoljeong.tripmate.infrastructer.external.events.listener;
+
+import com.yeoljeong.tripmate.application.service.command.PlanInternalCommandService;
+import com.yeoljeong.tripmate.event.OrderCreatedEvent;
+import com.yeoljeong.tripmate.event.enums.OrderTopic;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class OrderCreatedEventListener {
+
+  private final PlanInternalCommandService planInternalCommandService;
+
+  @KafkaListener (topics = OrderTopic.ORDER_CREATED_TOPIC, groupId = "plan-group")
+  public void orderCreated(OrderCreatedEvent event) { // ack 고려
+    try {
+
+      if (event == null) {
+        log.warn("[plan-service] 주문 생성 이벤트가 null입니다.");
+        return;
+      }
+
+      planInternalCommandService.addPlanUnitParticipant(event);
+      log.info("[plan-service] 메시지 업데이트 처리 완료 : eventId={} ", event.eventId());
+
+    } catch (Exception e) {
+      log.error("[plan-service] 메시지 업데이트 처리 실패 : {} ", e.getMessage(), e);
+      throw e;
+    }
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/external/events/listener/OrderCreatedEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/external/events/listener/OrderCreatedEventListener.java
@@ -16,8 +16,10 @@ public class OrderCreatedEventListener {
   private final PlanInternalCommandService planInternalCommandService;
 
   @KafkaListener (topics = OrderTopic.ORDER_CREATED_TOPIC, groupId = "plan-group")
-  public void orderCreated(OrderCreatedEvent event) { // ack 고려
+  public void orderCreated(OrderCreatedEvent event) { // todo: ack 고려
     try {
+
+      // todo: 이미 처리된 이벤트인지 확인(멱등성 추후 처리)
 
       if (event == null) {
         log.warn("[plan-service] 주문 생성 이벤트가 null입니다.");

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanUnitRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanUnitRepositoryImpl.java
@@ -24,4 +24,9 @@ public class PlanUnitRepositoryImpl implements PlanUnitRepository {
   public Optional<PlanUnit> findByIdAndPlanId(UUID planUnitId, UUID planId) {
     return jpaRepository.findByIdAndPlanId(planUnitId, planId);
   }
+
+  @Override
+  public Optional<PlanUnit> findById(UUID planUnitId) {
+    return jpaRepository.findById(planUnitId);
+  }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,8 +22,11 @@ spring:
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       properties:
         spring.json.add.type.headers: true # json 헤더에 클래스 타입 정보 추가로 수신서비스에서 자동 역직렬화 가능
-
-
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: "com.yeoljeong.tripmate.event" # 어느 패키지 클래스까지 변환 허용
 
 eureka:
   client:


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- close #18 
- `주문 생성` 이벤트 -> `일정 참여 인원 증가` 소비
### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
-  `OrderCreatedEventListener` 리스너 추가
-  참여인원 증가 로직 구현
-  kafka consumer 설정 추가

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 주문 생성 이벤트 수신 시 계획 단위 참여자를 자동으로 등록하도록 지원
  * 참여자 수를 누적해 최대 인원 초과 시 예외로 차단 및 유효성 검사 추가

* **Chores**
  * Kafka 소비자 설정 추가(직렬화 및 신뢰 패키지 지정)로 이벤트 처리 환경 구성

* **버그/오류 메시지**
  * 잘못된 참여 수 입력에 대한 명확한 오류 응답 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->