### PR TITLE
[Feat] 일정 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/application/dto/command/GetPlanCommand.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/dto/command/GetPlanCommand.java
@@ -1,0 +1,25 @@
+package com.yeoljeong.tripmate.application.dto.command;
+
+import com.yeoljeong.tripmate.domain.enums.RecruitStatus;
+import com.yeoljeong.tripmate.presentation.dto.request.PlanSearchCondition;
+import java.time.LocalDate;
+import org.springframework.data.domain.Pageable;
+
+public record GetPlanCommand(
+    String title,
+    LocalDate startDate,
+    LocalDate endDate,
+    RecruitStatus recruitStatus,
+    Pageable pageable
+) {
+
+  public static GetPlanCommand toCommand(Pageable pageable, PlanSearchCondition planSearchCondition) {
+    return new GetPlanCommand(
+        planSearchCondition.title(),
+        planSearchCondition.startDate(),
+        planSearchCondition.endDate(),
+        planSearchCondition.recruitStatus(),
+        pageable
+    );
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/application/service/query/PlanQueryService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/query/PlanQueryService.java
@@ -54,7 +54,7 @@ public class PlanQueryService {
   public Slice<GetPlanResponse> getPlan(GetPlanCommand command) {
     String title = command.title() == null || command.title().isBlank()
         ? null
-        : "&" + command.title().trim() + "%";
+        : "%" + command.title().trim() + "%";
 
     RecruitStatus recruitStatus = command.recruitStatus() == null
         ? RecruitStatus.OPEN

--- a/src/main/java/com/yeoljeong/tripmate/application/service/query/PlanQueryService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/query/PlanQueryService.java
@@ -1,6 +1,8 @@
 package com.yeoljeong.tripmate.application.service.query;
 
+import com.yeoljeong.tripmate.application.dto.command.GetPlanCommand;
 import com.yeoljeong.tripmate.application.dto.result.PlanUnitDetailResult;
+import com.yeoljeong.tripmate.domain.enums.RecruitStatus;
 import com.yeoljeong.tripmate.domain.exception.PlanErrorCode;
 import com.yeoljeong.tripmate.domain.model.plan.Plan;
 import com.yeoljeong.tripmate.domain.model.plan.PlanParticipation;
@@ -10,11 +12,13 @@ import com.yeoljeong.tripmate.domain.repository.PlanRepository;
 import com.yeoljeong.tripmate.domain.repository.PlanUnitRepository;
 import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.application.dto.result.GetPlanDetailResult;
+import com.yeoljeong.tripmate.presentation.dto.response.GetPlanResponse;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,5 +49,25 @@ public class PlanQueryService {
               )).toList();
     return GetPlanDetailResult.from(plan, planUnitResult);
 
+  }
+
+  public Slice<GetPlanResponse> getPlan(GetPlanCommand command) {
+    String title = command.title() == null || command.title().isBlank()
+        ? null
+        : "&" + command.title().trim() + "%";
+
+    RecruitStatus recruitStatus = command.recruitStatus() == null
+        ? RecruitStatus.OPEN
+        : command.recruitStatus();
+
+    Slice<Plan> plans = planRepository.findByCondition(
+        title,
+        command.startDate(),
+        command.endDate(),
+        recruitStatus,
+        command.pageable()
+    );
+
+    return plans.map(GetPlanResponse::from);
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanRepository.java
@@ -1,8 +1,12 @@
 package com.yeoljeong.tripmate.domain.repository;
 
+import com.yeoljeong.tripmate.domain.enums.RecruitStatus;
 import com.yeoljeong.tripmate.domain.model.plan.Plan;
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface PlanRepository {
 
@@ -11,4 +15,7 @@ public interface PlanRepository {
   boolean existsById(UUID planId);
 
   Optional<Plan> findById(UUID planId);
+
+  Slice<Plan> findByCondition(String title, LocalDate startDate, LocalDate endDate, RecruitStatus recruitStatus,
+      Pageable pageable);
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/jpa/PlanJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/jpa/PlanJpaRepository.java
@@ -1,9 +1,29 @@
 package com.yeoljeong.tripmate.infrastructer.persistence.jpa;
 
+import com.yeoljeong.tripmate.domain.enums.RecruitStatus;
 import com.yeoljeong.tripmate.domain.model.plan.Plan;
+import java.time.LocalDate;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PlanJpaRepository extends JpaRepository<Plan, UUID> {
 
+  @Query("""
+  select p
+    from Plan p
+      where p.recruitStatus = :recruitStatus
+        and (:title is null or p.title like :title)
+        and (:startDate is null or p.travelPeriod.startDate >= :startDate)
+        and (:endDate is null or p.travelPeriod.endDate <= :endDate)
+  """)
+  Slice<Plan> findByCondition(
+      @Param("title") String title,
+      @Param("startDate") LocalDate startDate,
+      @Param("endDate") LocalDate endDate,
+      @Param("recruitStatus") RecruitStatus recruitStatus,
+      Pageable pageable);
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanRepositoryImpl.java
@@ -1,11 +1,15 @@
 package com.yeoljeong.tripmate.infrastructer.persistence.repository;
 
+import com.yeoljeong.tripmate.domain.enums.RecruitStatus;
 import com.yeoljeong.tripmate.domain.model.plan.Plan;
 import com.yeoljeong.tripmate.domain.repository.PlanRepository;
 import com.yeoljeong.tripmate.infrastructer.persistence.jpa.PlanJpaRepository;
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -27,5 +31,11 @@ public class PlanRepositoryImpl implements PlanRepository {
   @Override
   public Optional<Plan> findById(UUID planId) {
     return jpaRepository.findById(planId);
+  }
+
+  @Override
+  public Slice<Plan> findByCondition(String title, LocalDate startDate, LocalDate endDate,
+      RecruitStatus recruitStatus, Pageable pageable) {
+    return jpaRepository.findByCondition(title, startDate, endDate, recruitStatus, pageable);
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/presentation/PlanController.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/PlanController.java
@@ -1,5 +1,6 @@
 package com.yeoljeong.tripmate.presentation;
 
+import com.yeoljeong.tripmate.application.dto.command.GetPlanCommand;
 import com.yeoljeong.tripmate.application.dto.command.ParticipatePlanCommand;
 import com.yeoljeong.tripmate.application.dto.result.ConfirmPlanUnitResult;
 import com.yeoljeong.tripmate.application.dto.result.GetPlanDetailResult;
@@ -9,19 +10,26 @@ import com.yeoljeong.tripmate.application.service.command.PlanCommandService;
 import com.yeoljeong.tripmate.application.dto.result.CreatePlanResult;
 import com.yeoljeong.tripmate.application.service.query.PlanQueryService;
 import com.yeoljeong.tripmate.presentation.dto.request.CreatePlanRequest;
+import com.yeoljeong.tripmate.presentation.dto.request.PlanSearchCondition;
 import com.yeoljeong.tripmate.presentation.dto.request.UpdateParticipationStatusRequest;
 import com.yeoljeong.tripmate.presentation.dto.response.ConfirmPlanUnitResponse;
 import com.yeoljeong.tripmate.presentation.dto.response.CreatePlanResponse;
 import com.yeoljeong.tripmate.presentation.dto.response.GetPlanDetailResponse;
 import com.yeoljeong.tripmate.presentation.dto.response.ParticipatePlanResponse;
 import com.yeoljeong.tripmate.presentation.dto.response.UpdateParticipationStatusResponse;
+import com.yeoljeong.tripmate.presentation.dto.response.GetPlanResponse;
 import com.yeoljeong.tripmate.response.ApiResponse;
 import com.yeoljeong.tripmate.response.constants.CommonSuccessCode;
 import jakarta.validation.Valid;
 import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -103,7 +111,17 @@ public class PlanController {
     GetPlanDetailResponse response = GetPlanDetailResponse.from(result);
 
     return ApiResponse.success(CommonSuccessCode.OK, "일정 상세 조회가 완료되었습니다.", response);
+  }
 
+  // 일정 목록 조회 (모든 사용자)
+  @GetMapping
+  public ApiResponse<Slice<GetPlanResponse>> getPlan(
+      @PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable,
+      @ModelAttribute PlanSearchCondition planSearchCondition // 검색 조건 dto 의도 명확
+  ) {
+    Slice<GetPlanResponse> response = planQueryService.getPlan(
+        GetPlanCommand.toCommand(pageable, planSearchCondition));
+    return ApiResponse.success(CommonSuccessCode.OK, "일정 목록 조회가 완료되었습니다.", response);
   }
 
 

--- a/src/main/java/com/yeoljeong/tripmate/presentation/dto/request/PlanSearchCondition.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/dto/request/PlanSearchCondition.java
@@ -1,0 +1,13 @@
+package com.yeoljeong.tripmate.presentation.dto.request;
+
+import com.yeoljeong.tripmate.domain.enums.RecruitStatus;
+import java.time.LocalDate;
+
+public record PlanSearchCondition(
+    String title,
+    LocalDate startDate,
+    LocalDate endDate,
+    RecruitStatus recruitStatus
+) {
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/presentation/dto/response/GetPlanResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/dto/response/GetPlanResponse.java
@@ -1,0 +1,27 @@
+package com.yeoljeong.tripmate.presentation.dto.response;
+
+import com.yeoljeong.tripmate.domain.enums.RecruitStatus;
+import com.yeoljeong.tripmate.domain.model.plan.Plan;
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record GetPlanResponse(
+    UUID PlanId,
+    String title,
+    String description,
+    LocalDate startDate,
+    LocalDate endDate,
+    RecruitStatus recruitStatus
+) {
+
+  public static GetPlanResponse from(Plan plan) {
+    return new GetPlanResponse(
+        plan.getId(),
+        plan.getTitle(),
+        plan.getDescription(),
+        plan.getTravelPeriod().getStartDate(),
+        plan.getTravelPeriod().getEndDate(),
+        plan.getRecruitStatus()
+    );
+  }
+}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- close #30 

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- 일정 목록 조회를 위한 dto 생성
- 일정 목록 조회를 위한 controller, service, repository 구현
- 

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
- 제목, 여행시작일, 여행종료일, 모집상태로 검색이 가능합니다.
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 여행 계획 검색 및 목록 조회(GET /plans) 기능이 추가되었습니다.
  * 제목, 여행 기간(시작일/종료일), 모집 상태로 필터링할 수 있습니다.
  * 제목은 부분 검색(contains)으로 지원되며 공백 처리됩니다.
  * 모집 상태를 지정하지 않으면 기본적으로 공개된 계획만 조회됩니다.
  * 페이징 지원으로 많은 계획을 효율적으로 탐색할 수 있습니다.
  * 응답에 계획 식별자, 제목, 설명, 여행 기간 및 모집 상태가 포함됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->