### PR TITLE
[Feat] 보상 트랜잭션 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+.env
 
 ### STS ###
 .apt_generated

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
-.env
+.env.*
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.yeoljeong:common-module:1.0.1-SNAPSHOT'
+    implementation 'com.yeoljeong:common-module:1.0.2-SNAPSHOT'
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/yeoljeong/tripmate/PlanServiceApplication.java
+++ b/src/main/java/com/yeoljeong/tripmate/PlanServiceApplication.java
@@ -5,11 +5,13 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableDiscoveryClient
 @EnableFeignClients
 @EnableJpaAuditing(auditorAwareRef = "userAuditorAware")
+@EnableScheduling
 public class PlanServiceApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/yeoljeong/tripmate/application/dto/command/internal/DeductPlanUnitParticipantCommand.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/dto/command/internal/DeductPlanUnitParticipantCommand.java
@@ -1,0 +1,23 @@
+package com.yeoljeong.tripmate.application.dto.command.internal;
+
+import com.yeoljeong.tripmate.event.ProductStockDeductFailedEvent;
+import java.util.UUID;
+
+public record DeductPlanUnitParticipantCommand(
+    UUID eventId,
+    UUID orderId,
+    UUID planUnitId,
+    UUID userId,
+    int quantity
+) {
+
+  public static DeductPlanUnitParticipantCommand from(ProductStockDeductFailedEvent event) {
+    return new DeductPlanUnitParticipantCommand(
+      event.eventId(),
+      event.orderId(),
+      event.planUnitId(),
+      event.userId(),
+      event.quantity()
+    );
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/application/port/PlanEvents.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/port/PlanEvents.java
@@ -12,4 +12,6 @@ public interface PlanEvents {
   void planUnitConfirmed(PlanUnitConfirmedEvent planUnitConfirmedEvent);
 
   void deductPlanUnitParticipant(UUID eventId, UUID orderId);
+
+  void addPlanUnitParticipantFailed(UUID eventId, UUID orderId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/application/port/PlanEvents.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/port/PlanEvents.java
@@ -14,4 +14,6 @@ public interface PlanEvents {
   void deductPlanUnitParticipant(UUID eventId, UUID orderId);
 
   void addPlanUnitParticipantFailed(UUID eventId, UUID orderId);
+
+  void deductPlanUnitParticipantFailed(UUID eventId, UUID orderId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/application/port/PlanEvents.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/port/PlanEvents.java
@@ -2,6 +2,7 @@ package com.yeoljeong.tripmate.application.port;
 
 import com.yeoljeong.tripmate.event.PlanUnitConfirmedEvent;
 import com.yeoljeong.tripmate.event.PlanUnitParticipantAddedEvent;
+import java.util.UUID;
 
 
 public interface PlanEvents {
@@ -9,4 +10,6 @@ public interface PlanEvents {
   void planUnitAddParticipant(PlanUnitParticipantAddedEvent planUnitParticipantAddedEvent);
 
   void planUnitConfirmed(PlanUnitConfirmedEvent planUnitConfirmedEvent);
+
+  void deductPlanUnitParticipant(UUID eventId, UUID orderId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanFailureEventService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanFailureEventService.java
@@ -1,0 +1,23 @@
+package com.yeoljeong.tripmate.application.service.command;
+
+import com.yeoljeong.tripmate.application.port.PlanEvents;
+import com.yeoljeong.tripmate.event.OrderCreatedEvent;
+import com.yeoljeong.tripmate.exception.BusinessException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PlanFailureEventService {
+
+  private final PlanEvents events;
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void addPlanUnitParticipantFailed(OrderCreatedEvent event, BusinessException e) {
+    // todo: e.message 전달
+    events.addPlanUnitParticipantFailed(UUID.randomUUID(), event.orderId());
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanFailureEventService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanFailureEventService.java
@@ -2,6 +2,7 @@ package com.yeoljeong.tripmate.application.service.command;
 
 import com.yeoljeong.tripmate.application.port.PlanEvents;
 import com.yeoljeong.tripmate.event.OrderCreatedEvent;
+import com.yeoljeong.tripmate.event.ProductStockDeductFailedEvent;
 import com.yeoljeong.tripmate.exception.BusinessException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -19,5 +20,10 @@ public class PlanFailureEventService {
   public void addPlanUnitParticipantFailed(OrderCreatedEvent event, BusinessException e) {
     // todo: e.message 전달
     events.addPlanUnitParticipantFailed(UUID.randomUUID(), event.orderId());
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void deductPlanUnitParticipantFailed(ProductStockDeductFailedEvent event, BusinessException e) {
+    events.deductPlanUnitParticipantFailed(UUID.randomUUID(), event.orderId());
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanInternalCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanInternalCommandService.java
@@ -70,8 +70,9 @@ public class PlanInternalCommandService {
     }
 
     // 이벤트 발행
-    events.planUnitAddParticipant(new PlanUnitParticipantAddedEvent(event.eventId(), event.productId(), event.scheduleId(), event.quantity()));
-
+    events.planUnitAddParticipant(
+        new PlanUnitParticipantAddedEvent(event.eventId(), event.productId(), event.scheduleId(),
+            event.planUnitId(), event.userId(), event.quantity()));
   }
 
   /*

--- a/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanInternalCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanInternalCommandService.java
@@ -13,7 +13,6 @@ import com.yeoljeong.tripmate.event.OrderCreatedEvent;
 import com.yeoljeong.tripmate.event.PaymentCompletedEvent;
 import com.yeoljeong.tripmate.event.PlanUnitParticipantAddedEvent;
 import com.yeoljeong.tripmate.exception.BusinessException;
-import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -111,8 +110,7 @@ public class PlanInternalCommandService {
   /*
    * 상품 재고 차감 실패시, 참여인원 감소 및 참여 상태 변경(RESERVED -> APPROVED) + 이벤트 발행
    * */
-  public void deductPlanUnitParticipant(DeductPlanUnitParticipantCommand command)
-      throws NoSuchAlgorithmException {
+  public void deductPlanUnitParticipant(DeductPlanUnitParticipantCommand command) {
     // todo: 멱등성 처리
     PlanUnit planUnit = planUnitRepository.findById(command.planUnitId())
         .orElseThrow(() -> new BusinessException(PlanErrorCode.PLAN_UNIT_NOT_FOUND));

--- a/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanInternalCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanInternalCommandService.java
@@ -1,5 +1,6 @@
 package com.yeoljeong.tripmate.application.service.command;
 
+import com.yeoljeong.tripmate.application.dto.command.internal.DeductPlanUnitParticipantCommand;
 import com.yeoljeong.tripmate.application.dto.result.FindParticipationStatusResult;
 import com.yeoljeong.tripmate.application.port.PlanEvents;
 import com.yeoljeong.tripmate.domain.enums.ParticipationStatus;
@@ -12,6 +13,7 @@ import com.yeoljeong.tripmate.event.OrderCreatedEvent;
 import com.yeoljeong.tripmate.event.PaymentCompletedEvent;
 import com.yeoljeong.tripmate.event.PlanUnitParticipantAddedEvent;
 import com.yeoljeong.tripmate.exception.BusinessException;
+import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,7 +38,7 @@ public class PlanInternalCommandService {
   }
 
   /*
-   * 주문 생성시, 참여인원 증가 및 상태 변경(APPROVED -> RESERVED)
+   * 주문 생성시, 참여인원 증가 및 상태 변경(APPROVED -> RESERVED) + 이벤트 발행
    * */
   public void addPlanUnitParticipant(OrderCreatedEvent event) {
 
@@ -44,11 +46,11 @@ public class PlanInternalCommandService {
     PlanUnit planUnit = planUnitRepository.findById(event.planUnitId())
         .orElseThrow(() -> new BusinessException(PlanErrorCode.PLAN_UNIT_NOT_FOUND));
 
-    PlanParticipation planParticipation = planParticipationRepository.findByPlanUnitAndUserId(
-            planUnit, event.userId())
+    PlanParticipation planParticipation = planParticipationRepository.findByPlanUnit_IdAndUserId(
+            planUnit.getId(), event.userId())
         .orElseThrow(() -> new BusinessException(PlanErrorCode.PLAN_PARTICIPATION_NOT_FOUND));
 
-    // 침야 싱테 검증
+    // 참여 싱테 검증
     planParticipation.validatePlanParticipationStatus(ParticipationStatus.RESERVED);
 
     // 참여 인원 검증
@@ -62,7 +64,7 @@ public class PlanInternalCommandService {
     }
 
     // 참여 상태 변경
-    int updatedStatus = planParticipationRepository.updateStatus(planUnit.getId(),
+    int updatedStatus = planParticipationRepository.updateStatus(planParticipation.getId(),
         planParticipation.getParticipationStatus(), ParticipationStatus.RESERVED);
 
     if (updatedStatus == 0) {
@@ -71,8 +73,17 @@ public class PlanInternalCommandService {
 
     // 이벤트 발행
     events.planUnitAddParticipant(
-        new PlanUnitParticipantAddedEvent(event.eventId(), event.productId(), event.scheduleId(),
-            event.planUnitId(), event.userId(), event.quantity()));
+        new PlanUnitParticipantAddedEvent(
+            UUID.randomUUID(),
+            event.orderId(),
+            event.productId(),
+            event.scheduleId(),
+            event.planUnitId(),
+            event.userId(),
+            event.quantity()
+        )
+    );
+
   }
 
   /*
@@ -97,4 +108,36 @@ public class PlanInternalCommandService {
     }
   }
 
+  /*
+   * 상품 재고 차감 실패시, 참여인원 감소 및 참여 상태 변경(RESERVED -> APPROVED) + 이벤트 발행
+   * */
+  public void deductPlanUnitParticipant(DeductPlanUnitParticipantCommand command)
+      throws NoSuchAlgorithmException {
+    // todo: 멱등성 처리
+    PlanUnit planUnit = planUnitRepository.findById(command.planUnitId())
+        .orElseThrow(() -> new BusinessException(PlanErrorCode.PLAN_UNIT_NOT_FOUND));
+
+    PlanParticipation participation = planParticipationRepository.findByPlanUnit_IdAndUserId(
+            command.planUnitId(), command.userId())
+        .orElseThrow(() -> new BusinessException(PlanErrorCode.PLAN_PARTICIPATION_NOT_FOUND));
+
+    // 참여 상태 변경 (RESERVED -> APPROVED)
+    int updatedStatus = planParticipationRepository.updateStatus(participation.getId(),
+        ParticipationStatus.RESERVED, ParticipationStatus.APPROVED);
+
+    if (updatedStatus == 0) {
+      throw new BusinessException(PlanErrorCode.PLAN_PARTICIPATION_STATUS_CHANGE_INVALID);
+    }
+
+    // 참여 현재인원 감소
+    planUnit.validatePositive(command.quantity());
+    int updatedCount = planUnitRepository.deductParticipantCount(command.planUnitId(), command.quantity());
+
+    if (updatedCount == 0) {
+      throw new BusinessException(PlanErrorCode.PLAN_UNIT_PARTICIPANT_UPDATE_QUANTITY_INVALID);
+    }
+
+    // 이벤트 발행
+    events.deductPlanUnitParticipant(UUID.randomUUID(), command.orderId());
+  }
 }

--- a/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanParticipationRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanParticipationRepository.java
@@ -28,5 +28,5 @@ public interface PlanParticipationRepository {
 
   List<PlanParticipation> findAllByPlanUnitIn(List<PlanUnit> planUnit);
 
-  int updateStatus(UUID planUnitId, ParticipationStatus participationStatus, ParticipationStatus status);
+  int updateStatus(UUID participationId, ParticipationStatus currentStatus, ParticipationStatus nextStatus);
 }

--- a/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanUnitRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanUnitRepository.java
@@ -17,4 +17,6 @@ public interface PlanUnitRepository {
   List<PlanUnit> findAllByPlanOrderByDayAscUnitTimeRange_StartTimeAsc(Plan plan);
 
   int addParticipantCount(UUID planUnitId, int quantity);
+
+  int deductParticipantCount(UUID planUnitId, int quantity);
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/KafkaDltConfig.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/KafkaDltConfig.java
@@ -1,0 +1,45 @@
+package com.yeoljeong.tripmate.infrastructer.messaging;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+@Slf4j
+@Configuration
+public class KafkaDltConfig {
+
+  @Value("${spring.retry.interval}")
+  private long interval;
+
+  @Value("${spring.retry.max-attempts}")
+  private long maxAttempts;
+
+  @Bean
+  public DefaultErrorHandler defaultErrorHandler(KafkaTemplate<String, String> kafkaTemplate) {
+    DeadLetterPublishingRecoverer recoverer =
+        new DeadLetterPublishingRecoverer(
+            kafkaTemplate,
+            (record, exception) -> {
+              String dltTopic = record.topic() + ".DLT";
+
+              log.error("[KAFKA-DLT] 메시지 DLT 전송 : originTopic={}, dltTopic={}, key={}, error={}",
+                  record.topic(),
+                  dltTopic,
+                  record.key(),
+                  exception.getMessage(),
+                  exception);
+
+              return new TopicPartition(dltTopic, (record.partition()));
+            }
+        );
+    FixedBackOff fixedBackOff = new FixedBackOff(interval, maxAttempts);
+
+    return new DefaultErrorHandler(recoverer, fixedBackOff);
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/KafkaDltConfig.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/KafkaDltConfig.java
@@ -14,11 +14,12 @@ import org.springframework.util.backoff.FixedBackOff;
 @Configuration
 public class KafkaDltConfig {
 
-  @Value("${spring.retry.interval}")
+  @Value("${spring.retry.interval:1000}")
   private long interval;
 
-  @Value("${spring.retry.max-attempts}")
+  @Value("${spring.retry.max-attempts:3}")
   private long maxAttempts;
+
 
   @Bean
   public DefaultErrorHandler defaultErrorHandler(KafkaTemplate<String, String> kafkaTemplate) {

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/KafkaPayloadDeserializer.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/KafkaPayloadDeserializer.java
@@ -1,5 +1,6 @@
 package com.yeoljeong.tripmate.infrastructer.messaging;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,12 +12,12 @@ import org.springframework.stereotype.Component;
 public class KafkaPayloadDeserializer {
   private final ObjectMapper objectMapper;
 
-  public <T> T deserialize(String payload, Class<T> clazz) {
+  public <T> T deserialize(String payload, Class<T> clazz) throws JsonProcessingException {
     try {
       return objectMapper.readValue(payload, clazz);
     } catch (Exception e) {
       log.error("[KAFKA] 역직렬화 실패 - class {},", clazz, e);
-      throw new RuntimeException(e);
+      throw e;
     }
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/KafkaPayloadDeserializer.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/KafkaPayloadDeserializer.java
@@ -1,0 +1,22 @@
+package com.yeoljeong.tripmate.infrastructer.messaging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class KafkaPayloadDeserializer {
+  private final ObjectMapper objectMapper;
+
+  public <T> T deserialize(String payload, Class<T> clazz) {
+    try {
+      return objectMapper.readValue(payload, clazz);
+    } catch (Exception e) {
+      log.error("[KAFKA] 역직렬화 실패 - class {},", clazz, e);
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/OrderEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/OrderEventListener.java
@@ -18,12 +18,12 @@ public class OrderEventListener {
   private final KafkaPayloadDeserializer kafkaPayloadDeserializer;
 
   @KafkaListener (topics = OrderTopic.ORDER_CREATED_TOPIC, groupId = "plan-group")
-  public void orderCreated(String s) { // todo: ack 고려
+  public void orderCreated(String message) { // todo: ack 고려
     try {
 
       // todo: 이미 처리된 이벤트인지 확인(멱등성 추후 처리)
 
-      OrderCreatedEvent event = kafkaPayloadDeserializer.deserialize(s, OrderCreatedEvent.class);
+      OrderCreatedEvent event = kafkaPayloadDeserializer.deserialize(message, OrderCreatedEvent.class);
 
       if (event == null) {
         log.warn("[plan-service] 주문 생성 이벤트가 null입니다.");

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/OrderEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/OrderEventListener.java
@@ -1,8 +1,10 @@
 package com.yeoljeong.tripmate.infrastructer.messaging.consumer;
 
+import com.yeoljeong.tripmate.application.service.command.PlanFailureEventService;
 import com.yeoljeong.tripmate.application.service.command.PlanInternalCommandService;
 import com.yeoljeong.tripmate.event.OrderCreatedEvent;
 import com.yeoljeong.tripmate.event.enums.OrderTopic;
+import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.infrastructer.messaging.KafkaPayloadDeserializer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,19 +18,30 @@ public class OrderEventListener {
 
   private final PlanInternalCommandService planInternalCommandService;
   private final KafkaPayloadDeserializer kafkaPayloadDeserializer;
+  private final PlanFailureEventService planFailureEventService;
 
   @KafkaListener (topics = OrderTopic.ORDER_CREATED_TOPIC, groupId = "plan-group")
-  public void orderCreated(String message) { // todo: ack 고려
+  public void orderCreated(String message) {
+
+    OrderCreatedEvent event = null;
+
     try {
 
       // todo: 이미 처리된 이벤트인지 확인(멱등성 추후 처리)
 
-      OrderCreatedEvent event = kafkaPayloadDeserializer.deserialize(message,
+      event = kafkaPayloadDeserializer.deserialize(message,
           OrderCreatedEvent.class);
 
       planInternalCommandService.addPlanUnitParticipant(event);
       log.info("[plan-service] 메시지 업데이트 처리 완료 : eventId={}, topic={}", event.eventId(),
           OrderTopic.ORDER_CREATED_TOPIC);
+
+    } catch (BusinessException e) {
+      log.warn("[plan-service] 주문 생성 이벤트 비즈니스 처리 실패. 실패 이벤트 발행 후 소비 완료 처리 : "
+              + "topic={}, eventId={}, orderId={}, planUnitId={}, error={}",
+          OrderTopic.ORDER_CREATED_TOPIC, event.eventId(), event.orderId(), event.planUnitId(),
+          e.getMessage(), e);
+      planFailureEventService.addPlanUnitParticipantFailed(event, e);
 
     } catch (Exception e) {
       log.error("[plan-service] 메시지 업데이트 처리 실패 : topic={}, error={}",

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/OrderEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/OrderEventListener.java
@@ -3,6 +3,7 @@ package com.yeoljeong.tripmate.infrastructer.messaging.consumer;
 import com.yeoljeong.tripmate.application.service.command.PlanInternalCommandService;
 import com.yeoljeong.tripmate.event.OrderCreatedEvent;
 import com.yeoljeong.tripmate.event.enums.OrderTopic;
+import com.yeoljeong.tripmate.infrastructer.messaging.KafkaPayloadDeserializer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -14,12 +15,15 @@ import org.springframework.stereotype.Component;
 public class OrderEventListener {
 
   private final PlanInternalCommandService planInternalCommandService;
+  private final KafkaPayloadDeserializer kafkaPayloadDeserializer;
 
   @KafkaListener (topics = OrderTopic.ORDER_CREATED_TOPIC, groupId = "plan-group")
-  public void orderCreated(OrderCreatedEvent event) { // todo: ack 고려
+  public void orderCreated(String s) { // todo: ack 고려
     try {
 
       // todo: 이미 처리된 이벤트인지 확인(멱등성 추후 처리)
+
+      OrderCreatedEvent event = kafkaPayloadDeserializer.deserialize(s, OrderCreatedEvent.class);
 
       if (event == null) {
         log.warn("[plan-service] 주문 생성 이벤트가 null입니다.");

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/OrderEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/OrderEventListener.java
@@ -1,5 +1,6 @@
 package com.yeoljeong.tripmate.infrastructer.messaging.consumer;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.yeoljeong.tripmate.application.service.command.PlanFailureEventService;
 import com.yeoljeong.tripmate.application.service.command.PlanInternalCommandService;
 import com.yeoljeong.tripmate.event.OrderCreatedEvent;
@@ -21,7 +22,7 @@ public class OrderEventListener {
   private final PlanFailureEventService planFailureEventService;
 
   @KafkaListener (topics = OrderTopic.ORDER_CREATED_TOPIC, groupId = "plan-group")
-  public void orderCreated(String message) {
+  public void orderCreated(String message) throws JsonProcessingException {
 
     OrderCreatedEvent event = null;
 

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/OrderEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/OrderEventListener.java
@@ -23,18 +23,16 @@ public class OrderEventListener {
 
       // todo: 이미 처리된 이벤트인지 확인(멱등성 추후 처리)
 
-      OrderCreatedEvent event = kafkaPayloadDeserializer.deserialize(message, OrderCreatedEvent.class);
-
-      if (event == null) {
-        log.warn("[plan-service] 주문 생성 이벤트가 null입니다.");
-        return;
-      }
+      OrderCreatedEvent event = kafkaPayloadDeserializer.deserialize(message,
+          OrderCreatedEvent.class);
 
       planInternalCommandService.addPlanUnitParticipant(event);
-      log.info("[plan-service] 메시지 업데이트 처리 완료 : eventId={} ", event.eventId());
+      log.info("[plan-service] 메시지 업데이트 처리 완료 : eventId={}, topic={}", event.eventId(),
+          OrderTopic.ORDER_CREATED_TOPIC);
 
     } catch (Exception e) {
-      log.error("[plan-service] 메시지 업데이트 처리 실패 : {} ", e.getMessage(), e);
+      log.error("[plan-service] 메시지 업데이트 처리 실패 : topic={}, error={}",
+          OrderTopic.ORDER_CREATED_TOPIC, e.getMessage(), e);
       throw e;
     }
   }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/PaymentEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/PaymentEventListener.java
@@ -3,6 +3,7 @@ package com.yeoljeong.tripmate.infrastructer.messaging.consumer;
 import com.yeoljeong.tripmate.application.service.command.PlanInternalCommandService;
 import com.yeoljeong.tripmate.event.PaymentCompletedEvent;
 import com.yeoljeong.tripmate.event.enums.PaymentTopic;
+import com.yeoljeong.tripmate.infrastructer.messaging.KafkaPayloadDeserializer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -13,10 +14,15 @@ import org.springframework.stereotype.Component;
 @Component
 public class PaymentEventListener {
   private final PlanInternalCommandService planInternalCommandService;
+  private final KafkaPayloadDeserializer kafkaPayloadDeserializer;
 
   @KafkaListener(topics = PaymentTopic.PAYMENT_COMPLETED_TOPIC, groupId = "plan-group")
-  public void paymentCompleted(PaymentCompletedEvent event) {
+  public void paymentCompleted(String message) {
     try {
+
+      PaymentCompletedEvent event = kafkaPayloadDeserializer.deserialize(message,
+          PaymentCompletedEvent.class);
+
       if (event == null) {
         log.warn("[plan-service] 결제 완료 이벤트가 null입니다.");
         return;

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/PaymentEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/PaymentEventListener.java
@@ -23,15 +23,14 @@ public class PaymentEventListener {
       PaymentCompletedEvent event = kafkaPayloadDeserializer.deserialize(message,
           PaymentCompletedEvent.class);
 
-      if (event == null) {
-        log.warn("[plan-service] 결제 완료 이벤트가 null입니다.");
-        return;
-      }
       planInternalCommandService.updateParticipantStatus(event);
-      log.info("[plan-service] 메시지 업데이트 처리 완료 : eventId={} ", event.eventHash());
+      log.info("[plan-service] 메시지 업데이트 처리 완료 : eventId={}, topic={}", event.eventHash(),
+          PaymentTopic.PAYMENT_COMPLETED_TOPIC);
 
     } catch (Exception e) {
-      log.error("[plan-service] 메시지 업데이트 처리 실패 : {} ", e.getMessage(), e);
+      log.error("[plan-service] 메시지 업데이트 처리 실패 : topic={}, error={} ",
+          PaymentTopic.PAYMENT_COMPLETED_TOPIC,
+          e.getMessage(), e);
       throw e;
     }
   }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/PaymentEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/PaymentEventListener.java
@@ -1,5 +1,6 @@
 package com.yeoljeong.tripmate.infrastructer.messaging.consumer;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.yeoljeong.tripmate.application.service.command.PlanInternalCommandService;
 import com.yeoljeong.tripmate.event.PaymentCompletedEvent;
 import com.yeoljeong.tripmate.event.enums.PaymentTopic;
@@ -17,7 +18,7 @@ public class PaymentEventListener {
   private final KafkaPayloadDeserializer kafkaPayloadDeserializer;
 
   @KafkaListener(topics = PaymentTopic.PAYMENT_COMPLETED_TOPIC, groupId = "plan-group")
-  public void paymentCompleted(String message) {
+  public void paymentCompleted(String message) throws JsonProcessingException {
     try {
 
       PaymentCompletedEvent event = kafkaPayloadDeserializer.deserialize(message,

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/ProductEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/ProductEventListener.java
@@ -1,0 +1,44 @@
+package com.yeoljeong.tripmate.infrastructer.messaging.consumer;
+
+import com.yeoljeong.tripmate.application.dto.command.internal.DeductPlanUnitParticipantCommand;
+import com.yeoljeong.tripmate.application.service.command.PlanInternalCommandService;
+import com.yeoljeong.tripmate.event.ProductStockDeductFailedEvent;
+import com.yeoljeong.tripmate.event.enums.ProductTopic;
+import com.yeoljeong.tripmate.infrastructer.messaging.KafkaPayloadDeserializer;
+import java.security.NoSuchAlgorithmException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductEventListener {
+
+  private final PlanInternalCommandService planInternalCommandService;
+  private final KafkaPayloadDeserializer kafkaPayloadDeserializer;
+
+  @KafkaListener(topics = ProductTopic.STOCK_DEDUCT_FAILED_TOPIC, groupId = "plan-group")
+  public void productStockDeductFailed(String message) throws NoSuchAlgorithmException {
+
+    try {
+      ProductStockDeductFailedEvent event = kafkaPayloadDeserializer.deserialize(message,
+          ProductStockDeductFailedEvent.class);
+
+      if (event == null) {
+        log.warn("[plan-service] 상품 재고 차감 실패 이벤트가 null입니다.");
+      }
+      planInternalCommandService.deductPlanUnitParticipant(DeductPlanUnitParticipantCommand.from(event));
+      log.info("[plan-service] 메시지 업데이트 처리 완료: eventId={}", event.eventId());
+
+    } catch (Exception e) {
+      log.error("[plan-service] 메시지 업데이트 처리 실패: {}", e.getMessage(), e);
+      throw e;
+    }
+
+
+
+  }
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/ProductEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/ProductEventListener.java
@@ -1,9 +1,12 @@
 package com.yeoljeong.tripmate.infrastructer.messaging.consumer;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.yeoljeong.tripmate.application.dto.command.internal.DeductPlanUnitParticipantCommand;
+import com.yeoljeong.tripmate.application.service.command.PlanFailureEventService;
 import com.yeoljeong.tripmate.application.service.command.PlanInternalCommandService;
 import com.yeoljeong.tripmate.event.ProductStockDeductFailedEvent;
 import com.yeoljeong.tripmate.event.enums.ProductTopic;
+import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.infrastructer.messaging.KafkaPayloadDeserializer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,19 +20,26 @@ public class ProductEventListener {
 
   private final PlanInternalCommandService planInternalCommandService;
   private final KafkaPayloadDeserializer kafkaPayloadDeserializer;
+  private final PlanFailureEventService planFailureEventService;
 
   @KafkaListener(topics = ProductTopic.STOCK_DEDUCT_FAILED_TOPIC, groupId = "plan-group")
-  public void productStockDeductFailed(String message) {
+  public void productStockDeductFailed(String message) throws JsonProcessingException {
+
+    ProductStockDeductFailedEvent event = null;
 
     try {
 
-      ProductStockDeductFailedEvent event = kafkaPayloadDeserializer.deserialize(message,
+      event = kafkaPayloadDeserializer.deserialize(message,
           ProductStockDeductFailedEvent.class);
 
       planInternalCommandService.deductPlanUnitParticipant(DeductPlanUnitParticipantCommand.from(event));
       log.info("[plan-service] 메시지 업데이트 처리 완료: eventId={}, topic={}", event.eventId(),
           ProductTopic.STOCK_DEDUCT_FAILED_TOPIC);
 
+    } catch (BusinessException e) {
+      log.warn("[plan-service] 참여 인원 감소 비즈니스 실패: eventId={}, orderId={}, error={}",
+          event.eventId(), event.orderId(), e.getMessage());
+      planFailureEventService.deductPlanUnitParticipantFailed(event, e); // 주문 취소 이벤트 발행
     } catch (Exception e) {
       log.error("[plan-service] 메시지 업데이트 처리 실패: topic={}, error={}",
           ProductTopic.STOCK_DEDUCT_FAILED_TOPIC, e.getMessage(), e);

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/ProductEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/ProductEventListener.java
@@ -5,7 +5,6 @@ import com.yeoljeong.tripmate.application.service.command.PlanInternalCommandSer
 import com.yeoljeong.tripmate.event.ProductStockDeductFailedEvent;
 import com.yeoljeong.tripmate.event.enums.ProductTopic;
 import com.yeoljeong.tripmate.infrastructer.messaging.KafkaPayloadDeserializer;
-import java.security.NoSuchAlgorithmException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -20,7 +19,7 @@ public class ProductEventListener {
   private final KafkaPayloadDeserializer kafkaPayloadDeserializer;
 
   @KafkaListener(topics = ProductTopic.STOCK_DEDUCT_FAILED_TOPIC, groupId = "plan-group")
-  public void productStockDeductFailed(String message) throws NoSuchAlgorithmException {
+  public void productStockDeductFailed(String message) {
 
     try {
 

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/ProductEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/consumer/ProductEventListener.java
@@ -23,22 +23,19 @@ public class ProductEventListener {
   public void productStockDeductFailed(String message) throws NoSuchAlgorithmException {
 
     try {
+
       ProductStockDeductFailedEvent event = kafkaPayloadDeserializer.deserialize(message,
           ProductStockDeductFailedEvent.class);
 
-      if (event == null) {
-        log.warn("[plan-service] 상품 재고 차감 실패 이벤트가 null입니다.");
-      }
       planInternalCommandService.deductPlanUnitParticipant(DeductPlanUnitParticipantCommand.from(event));
-      log.info("[plan-service] 메시지 업데이트 처리 완료: eventId={}", event.eventId());
+      log.info("[plan-service] 메시지 업데이트 처리 완료: eventId={}, topic={}", event.eventId(),
+          ProductTopic.STOCK_DEDUCT_FAILED_TOPIC);
 
     } catch (Exception e) {
-      log.error("[plan-service] 메시지 업데이트 처리 실패: {}", e.getMessage(), e);
+      log.error("[plan-service] 메시지 업데이트 처리 실패: topic={}, error={}",
+          ProductTopic.STOCK_DEDUCT_FAILED_TOPIC, e.getMessage(), e);
       throw e;
     }
-
-
-
   }
 
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/producer/PlanEventsAdaptor.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/producer/PlanEventsAdaptor.java
@@ -3,6 +3,7 @@ package com.yeoljeong.tripmate.infrastructer.messaging.producer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yeoljeong.tripmate.application.port.PlanEvents;
+import com.yeoljeong.tripmate.event.PlanUnitAddParticipantFailedEvent;
 import com.yeoljeong.tripmate.event.PlanUnitConfirmedEvent;
 import com.yeoljeong.tripmate.event.PlanUnitDeductParticipantEvent;
 import com.yeoljeong.tripmate.event.PlanUnitParticipantAddedEvent;
@@ -66,6 +67,28 @@ public class PlanEventsAdaptor implements PlanEvents {
           "[plan-service] 참여 인원 감소 이벤트 직렬화 실패: eventId={}, topic={}",
           eventId,
           PlanTopic.PLAN_UNIT_PARTICIPANT_DEDUCTED_TOPIC,
+          e
+      );
+      throw new RuntimeException("이벤트 직렬화 실패", e);
+    }
+  }
+
+  /* 참여 현재 인원 증가 실패 이벤트*/
+  @Override
+  public void addPlanUnitParticipantFailed(UUID eventId, UUID orderId) {
+    try {
+      PlanUnitAddParticipantFailedEvent payload = new PlanUnitAddParticipantFailedEvent(eventId,
+          orderId);
+      String json = objectMapper.writeValueAsString(payload);
+
+      outBoxRepository.save(
+          PlanOutbox.create(PlanTopic.PLAN_UNIT_PARTICIPANT_ADD_FAILED_TOPIC, json)
+      );
+    } catch (JsonProcessingException e) {
+      log.error(
+          "[plan-service] 참여 인원 증가 실패 이벤트 직렬화 실패: eventId={}, topic={}",
+          eventId,
+          PlanTopic.PLAN_UNIT_PARTICIPANT_ADD_FAILED_TOPIC,
           e
       );
       throw new RuntimeException("이벤트 직렬화 실패", e);

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/producer/PlanEventsAdaptor.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/producer/PlanEventsAdaptor.java
@@ -4,13 +4,17 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yeoljeong.tripmate.application.port.PlanEvents;
 import com.yeoljeong.tripmate.event.PlanUnitConfirmedEvent;
+import com.yeoljeong.tripmate.event.PlanUnitDeductParticipantEvent;
 import com.yeoljeong.tripmate.event.PlanUnitParticipantAddedEvent;
 import com.yeoljeong.tripmate.event.enums.PlanTopic;
 import com.yeoljeong.tripmate.infrastructer.persistence.PlanOutbox;
 import com.yeoljeong.tripmate.infrastructer.persistence.jpa.PlanOutBoxRepository;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PlanEventsAdaptor implements PlanEvents {
@@ -40,6 +44,30 @@ public class PlanEventsAdaptor implements PlanEvents {
       );
 
     } catch (JsonProcessingException e) {
+      throw new RuntimeException("이벤트 직렬화 실패", e);
+    }
+  }
+
+  /* 참여 현재 인원 감소 이벤트*/
+  @Override
+  public void deductPlanUnitParticipant(UUID eventId, UUID orderId) {
+
+    try {
+      PlanUnitDeductParticipantEvent payload = new PlanUnitDeductParticipantEvent(
+          eventId, orderId);
+
+      String json = objectMapper.writeValueAsString(payload);
+      outBoxRepository.save(
+          PlanOutbox.create(PlanTopic.PLAN_UNIT_PARTICIPANT_DEDUCTED_TOPIC,
+              json)
+      );
+    } catch (JsonProcessingException e) {
+      log.error(
+          "[plan-service] 참여 인원 감소 이벤트 직렬화 실패: eventId={}, topic={}",
+          eventId,
+          PlanTopic.PLAN_UNIT_PARTICIPANT_DEDUCTED_TOPIC,
+          e
+      );
       throw new RuntimeException("이벤트 직렬화 실패", e);
     }
   }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/producer/PlanEventsAdaptor.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/producer/PlanEventsAdaptor.java
@@ -94,4 +94,28 @@ public class PlanEventsAdaptor implements PlanEvents {
       throw new RuntimeException("이벤트 직렬화 실패", e);
     }
   }
+
+  /* 참여 현재 인원 감소 실패 이벤트*/
+  @Override
+  public void deductPlanUnitParticipantFailed(UUID eventId, UUID orderId) {
+    try {
+      PlanUnitDeductParticipantEvent payload = new PlanUnitDeductParticipantEvent(eventId,
+          orderId);
+      String json = objectMapper.writeValueAsString(payload);
+
+      outBoxRepository.save(
+          // todo: common모듈 추가
+          PlanOutbox.create("plan.unit.participant.deduct.failed", json)
+      );
+    } catch (JsonProcessingException e) {
+      log.error(
+          "[plan-service] 참여 인원 감소 실패 이벤트 직렬화 실패: eventId={}, topic={}",
+          eventId,
+          "plan.unit.participant.deduct.failed",
+          e
+      );
+      throw new RuntimeException("이벤트 직렬화 실패", e);
+    }
+
+  }
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/jpa/PlanParticipationJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/jpa/PlanParticipationJpaRepository.java
@@ -32,11 +32,11 @@ public interface PlanParticipationJpaRepository extends JpaRepository<PlanPartic
   @Query("""
     update PlanParticipation p
       set p.participationStatus = :nextStatus
-        where p.planUnit.id = :planUnitId
+        where p.id = :participationId
             and p.participationStatus = :currentStatus
   """)
   int updateStatus(
-      @Param("planUnitId") UUID planUnitId,
+      @Param("participationId") UUID participationId,
       @Param("currentStatus") ParticipationStatus currentStatus,
       @Param("nextStatus") ParticipationStatus nextStatus);
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/jpa/PlanUnitJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/jpa/PlanUnitJpaRepository.java
@@ -24,4 +24,14 @@ public interface PlanUnitJpaRepository extends JpaRepository<PlanUnit, UUID> {
          and u.participantCount.currentCount + :quantity <= u.participantCount.maxCount
   """)
   int addParticipantCount(@Param("planUnitId") UUID planUnitId, @Param("quantity") int quantity);
+
+  @Modifying
+  @Query("""
+   update PlanUnit u
+     set u.participantCount.currentCount = u.participantCount.currentCount - :quantity
+       where u.id = :planUnitId
+         and u.participantCount.currentCount - :quantity <= u.participantCount.maxCount
+         and u.participantCount.currentCount - :quantity >= 0
+  """)
+  int deductParticipantCount(@Param("planUnitId") UUID planUnitId,@Param("quantity") int quantity);
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanUnitRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanUnitRepositoryImpl.java
@@ -40,4 +40,9 @@ public class PlanUnitRepositoryImpl implements PlanUnitRepository {
   public int addParticipantCount(UUID planUnitId, int quantity) {
     return jpaRepository.addParticipantCount(planUnitId, quantity);
   }
+
+  @Override
+  public int deductParticipantCount(UUID planUnitId, int quantity) {
+    return jpaRepository.deductParticipantCount(planUnitId, quantity);
+  }
 }

--- a/src/main/java/com/yeoljeong/tripmate/presentation/external/PlanController.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/external/PlanController.java
@@ -9,6 +9,8 @@ import com.yeoljeong.tripmate.application.dto.result.UpdateParticipationStatusRe
 import com.yeoljeong.tripmate.application.service.command.PlanCommandService;
 import com.yeoljeong.tripmate.application.dto.result.CreatePlanResult;
 import com.yeoljeong.tripmate.application.service.query.PlanQueryService;
+import com.yeoljeong.tripmate.auth.annotation.LoginUser;
+import com.yeoljeong.tripmate.auth.context.UserContext;
 import com.yeoljeong.tripmate.presentation.dto.request.CreatePlanRequest;
 import com.yeoljeong.tripmate.presentation.dto.request.PlanSearchCondition;
 import com.yeoljeong.tripmate.presentation.dto.request.UpdateParticipationStatusRequest;
@@ -34,7 +36,6 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -48,10 +49,10 @@ public class PlanController {
 
   @PostMapping
   public ApiResponse<CreatePlanResponse> createPlans(
-      @RequestHeader("X-User-Id") UUID userId,
+      @LoginUser UserContext user,
       @RequestBody @Valid CreatePlanRequest createPlanRequest) {
 
-    CreatePlanResult result = planCommandService.createPlans(createPlanRequest.toCommand(userId));
+    CreatePlanResult result = planCommandService.createPlans(createPlanRequest.toCommand(user.userId()));
     CreatePlanResponse response = CreatePlanResponse.from(result);
     return ApiResponse.success(CommonSuccessCode.OK, "일정 등록이 되었습니다.", response);
   }
@@ -59,12 +60,12 @@ public class PlanController {
 
   @PostMapping("/{planId}/unit-plans/{unitPlanId}/participations")
   public ApiResponse<ParticipatePlanResponse> participatePlan(
-      @RequestHeader("X-User-Id") UUID userId,
+      @LoginUser UserContext user,
       @PathVariable("planId") UUID planId,
       @PathVariable("unitPlanId") UUID planUnitId) {
 
     ParticipatePlanResult result =
-        planCommandService.participatePlanUnit(new ParticipatePlanCommand(userId, planId, planUnitId));
+        planCommandService.participatePlanUnit(new ParticipatePlanCommand(user.userId(), planId, planUnitId));
     ParticipatePlanResponse response = ParticipatePlanResponse.from(result);
 
     return ApiResponse.success(CommonSuccessCode.OK, "일정 참여 신청이 완료되었습니다.",
@@ -73,7 +74,7 @@ public class PlanController {
 
   @PatchMapping("/{planId}/unit-plans/{unitPlanId}/participations/{participationId}/status")
   public ApiResponse<UpdateParticipationStatusResponse> updateParticipationStatus(
-      @RequestHeader("X-User-Id") UUID userId,
+      @LoginUser UserContext user,
       @PathVariable("planId") UUID planId,
       @PathVariable("unitPlanId") UUID planUnitId,
       @PathVariable("participationId") UUID participationId,
@@ -81,7 +82,7 @@ public class PlanController {
 
     UpdateParticipationStatusResult result =
         planCommandService.updateParticipationStatus(
-            request.toCommand(userId, planId, planUnitId, participationId));
+            request.toCommand(user.userId(), planId, planUnitId, participationId));
 
     UpdateParticipationStatusResponse response = UpdateParticipationStatusResponse.from(result);
 
@@ -94,9 +95,9 @@ public class PlanController {
   public ApiResponse<ConfirmPlanUnitResponse> confirmPlanUnit(
       @PathVariable("planId") UUID planId,
       @PathVariable("unitPlanId") UUID planUnitId,
-      @RequestHeader("X-User-Id") UUID userId
-  ) throws NoSuchAlgorithmException {
-    ConfirmPlanUnitResult result = planCommandService.confirmPlanUnit(planId, planUnitId, userId);
+      @LoginUser UserContext user
+      ) throws NoSuchAlgorithmException {
+    ConfirmPlanUnitResult result = planCommandService.confirmPlanUnit(planId, planUnitId, user.userId());
     ConfirmPlanUnitResponse response = ConfirmPlanUnitResponse.from(result);
 
     return ApiResponse.success(CommonSuccessCode.OK, "일정이 확정되었습니다.", response);

--- a/src/main/resources/application-kafka.yml
+++ b/src/main/resources/application-kafka.yml
@@ -11,6 +11,9 @@ spring:
       enable-auto-commit: false # Spring Kafka가 리스너 처리 성공 후 커밋
       auto-offset-reset: earliest # offset이 없을때 어디서 부터 읽을지 설정
 
-
     listener:
       ack-mode: record # 메시지 처리할때마다 commit
+
+  retry:
+    interval: 1000
+    max-attempts: 3

--- a/src/main/resources/application-kafka.yml
+++ b/src/main/resources/application-kafka.yml
@@ -1,0 +1,10 @@
+spring:
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/src/main/resources/application-kafka.yml
+++ b/src/main/resources/application-kafka.yml
@@ -8,3 +8,9 @@ spring:
     consumer:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      enable-auto-commit: false # Spring Kafka가 리스너 처리 성공 후 커밋
+      auto-offset-reset: earliest # offset이 없을때 어디서 부터 읽을지 설정
+
+
+    listener:
+      ack-mode: record # 메시지 처리할때마다 commit

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 18080
+  port: 8080
 spring:
   application:
     name: plan-service
@@ -13,20 +13,10 @@ spring:
       ddl-auto: ${DB_DDL_AUTO}
     properties:
       hibernate:
-        show_sql: ${JPA_SHOW_SQL:false}
-        format_sql: true
-  kafka:
-    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
-    producer:
-      key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-      properties:
-        spring.json.add.type.headers: true # json 헤더에 클래스 타입 정보 추가로 수신서비스에서 자동 역직렬화 가능
-    consumer:
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
-      properties:
-        spring.json.trusted.packages: "com.yeoljeong.tripmate.event" # 어느 패키지 클래스까지 변환 허용
+#        show_sql: ${JPA_SHOW_SQL:false}
+#        format_sql: false
+jwt:
+  internal-secret: ${JWT_INTERNAL_SECRET}
 
 ## 로컬 설정
 eureka:
@@ -43,11 +33,11 @@ eureka:
 #eureka:
 #  client:
 #    service-url:
-    #      defaultZone: ${defaultZone:https://dolphin-device-evident.ngrok-free.dev/eureka/}
+#          defaultZone: ${defaultZone:https://dolphin-device-evident.ngrok-free.dev/eureka/}
 #    register-with-eureka: true
 #    fetch-registry: true
 #  instance:
-#    hostname: "3b06-2406-5900-1073-1b8-90e9-4e2e-b463-19bc.ngrok-free.app"
+#    hostname: "fe22-2406-5900-1073-1b8-20da-5627-db0e-e14a.ngrok-free.app"
 #    non-secure-port: 80
 #    secure-port: 443
 #    prefer-ip-address: false


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- close #47 
- 상품 재고 차감 실패 이벤트 수신
- 일정 참여 인원 증가 실패 이벤트 발행
- 일정 참여 인원 감소 실패 이벤트 발행
### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- [refactor: 헤더에 X-User-Id 제거 후](https://github.com/10jeong/plan-service/commit/8e11837bb7a5b596c5396147998a3f6982b9c11b) @loginuser [추가](https://github.com/10jeong/plan-service/commit/8e11837bb7a5b596c5396147998a3f6982b9c11b)
- [feat: 재고차감 실패 이벤트 수신](https://github.com/10jeong/plan-service/commit/26b9af519c38976e892d2b747fefd1c2e35f6c23)
- [feat: 일정 인정 감소 이벤트 발행](https://github.com/10jeong/plan-service/commit/b50e63dab94f09295e14ed77031446e147e43b84)
- [feat: 일정 참여 인원 증가 실패 이벤트 발행](https://github.com/10jeong/plan-service/commit/20f70e016c16cb94e77206c4acbd1e7eb6c59e95)

@oni128
### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 상품 재고 차감 실패 시 자동 복구 및 내부 복구 이벤트 처리 추가
  * 메시지 기반 이벤트 소비자 추가로 실패 복구 흐름 개선

* **버그 수정 / 개선**
  * 주문/결제 처리 중 비즈니스 예외에 대한 처리 및 재시도/대체 경로 강화
  * 사용자 인증 정보 전달 방식 개선(헤더 → 로그인 컨텍스트)

* **Chores**
  * Kafka 설정 및 DLT/재시도 정책 추가
  * 서버 포트 변경(18080 → 8080), 의존성 버전 업데이트, .env 파일 git 무시 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/10jeong/plan-service/pull/48)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->