### PR TITLE
[Feat] 일정 참여 탈퇴 이벤트 발행

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/application/dto/command/WithdrawPlanUnitParticipationCommand.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/dto/command/WithdrawPlanUnitParticipationCommand.java
@@ -5,14 +5,16 @@ import java.util.UUID;
 
 public record WithdrawPlanUnitParticipationCommand(
     String reason,
+    UUID planId,
     UUID planUnitId,
     UUID participationId,
     UUID userId
 ) {
 
-  public static WithdrawPlanUnitParticipationCommand from(withdrawPlanUnitParticipationRequest request, UUID planUnitId, UUID participationId, UUID userId) {
+  public static WithdrawPlanUnitParticipationCommand from(withdrawPlanUnitParticipationRequest request, UUID planId, UUID planUnitId, UUID participationId, UUID userId) {
     return new WithdrawPlanUnitParticipationCommand(
         request.reason(),
+        planId,
         planUnitId,
         participationId,
         userId

--- a/src/main/java/com/yeoljeong/tripmate/application/dto/command/WithdrawPlanUnitParticipationCommand.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/dto/command/WithdrawPlanUnitParticipationCommand.java
@@ -1,0 +1,21 @@
+package com.yeoljeong.tripmate.application.dto.command;
+
+import com.yeoljeong.tripmate.presentation.dto.request.withdrawPlanUnitParticipationRequest;
+import java.util.UUID;
+
+public record WithdrawPlanUnitParticipationCommand(
+    String reason,
+    UUID planUnitId,
+    UUID participationId,
+    UUID userId
+) {
+
+  public static WithdrawPlanUnitParticipationCommand from(withdrawPlanUnitParticipationRequest request, UUID planUnitId, UUID participationId, UUID userId) {
+    return new WithdrawPlanUnitParticipationCommand(
+        request.reason(),
+        planUnitId,
+        participationId,
+        userId
+    );
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/application/port/PlanEvents.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/port/PlanEvents.java
@@ -2,7 +2,6 @@ package com.yeoljeong.tripmate.application.port;
 
 import com.yeoljeong.tripmate.event.PlanUnitConfirmedEvent;
 import com.yeoljeong.tripmate.event.PlanUnitParticipantAddedEvent;
-import com.yeoljeong.tripmate.event.PlanUnitParticipantQuitEvent;
 import java.util.UUID;
 
 
@@ -18,5 +17,5 @@ public interface PlanEvents {
 
   void deductPlanUnitParticipantFailed(UUID eventId, UUID orderId);
 
-  void planUnitParticipationQuit(UUID eventId, UUID userId, UUID planUnitId);
+  void planUnitParticipationQuit(UUID eventId, UUID userId, UUID planUnitId, String reason);
 }

--- a/src/main/java/com/yeoljeong/tripmate/application/port/PlanEvents.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/port/PlanEvents.java
@@ -2,6 +2,7 @@ package com.yeoljeong.tripmate.application.port;
 
 import com.yeoljeong.tripmate.event.PlanUnitConfirmedEvent;
 import com.yeoljeong.tripmate.event.PlanUnitParticipantAddedEvent;
+import com.yeoljeong.tripmate.event.PlanUnitParticipantQuitEvent;
 import java.util.UUID;
 
 
@@ -16,4 +17,6 @@ public interface PlanEvents {
   void addPlanUnitParticipantFailed(UUID eventId, UUID orderId);
 
   void deductPlanUnitParticipantFailed(UUID eventId, UUID orderId);
+
+  void planUnitParticipationQuit(UUID eventId, UUID userId, UUID planUnitId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanCommandService.java
@@ -219,11 +219,7 @@ public class PlanCommandService {
     participation.withdraw(userId);
 
     // 이벤트 발행
-    events.planUnitParticipationQuit(new PlanUnitParticipantQuitEvent(
-        UUID.randomUUID(),
-        userId,
-        planUnitId
-    ));
+    events.planUnitParticipationQuit(UUID.randomUUID(), userId, planUnitId);
 
     return WithdrawPlanUnitParticipationResponse.from(participation);
   }

--- a/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanCommandService.java
@@ -4,6 +4,7 @@ import com.yeoljeong.tripmate.application.dto.command.CreatePlanCommand;
 import com.yeoljeong.tripmate.application.dto.command.CreatePlanUnitCommand;
 import com.yeoljeong.tripmate.application.dto.command.ParticipatePlanCommand;
 import com.yeoljeong.tripmate.application.dto.command.UpdateParticipationStatusCommand;
+import com.yeoljeong.tripmate.application.dto.command.WithdrawPlanUnitParticipationCommand;
 import com.yeoljeong.tripmate.application.dto.result.ConfirmPlanUnitResult;
 import com.yeoljeong.tripmate.application.dto.result.CreatePlanResult;
 import com.yeoljeong.tripmate.application.dto.result.ParticipatePlanResult;
@@ -210,16 +211,16 @@ public class PlanCommandService {
   * 참여 일정 탈퇴
   * : 참여 상태가 CONFIRMED인 사용자만 가능
   * */
-  public WithdrawPlanUnitParticipationResponse withdrawPlanUnitParticipant(UUID planId, UUID planUnitId, UUID participationId, UUID userId) {
-
+  public WithdrawPlanUnitParticipationResponse withdrawPlanUnitParticipant(
+      WithdrawPlanUnitParticipationCommand command) {
     PlanParticipation participation = planParticipationRepository.findById(
-            participationId)
+            command.participationId())
         .orElseThrow(() -> new BusinessException(PlanErrorCode.PLAN_PARTICIPATION_NOT_FOUND));
 
-    participation.withdraw(userId);
+    participation.withdraw(command.userId());
 
     // 이벤트 발행
-    events.planUnitParticipationQuit(UUID.randomUUID(), userId, planUnitId);
+    events.planUnitParticipationQuit(UUID.randomUUID(), command.userId(), command.planUnitId(), command.reason());
 
     return WithdrawPlanUnitParticipationResponse.from(participation);
   }

--- a/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanCommandService.java
@@ -213,14 +213,17 @@ public class PlanCommandService {
   * */
   public WithdrawPlanUnitParticipationResponse withdrawPlanUnitParticipant(
       WithdrawPlanUnitParticipationCommand command) {
-    PlanParticipation participation = planParticipationRepository.findById(
-            command.participationId())
+    PlanUnit planUnit = planUnitRepository.findById(command.planUnitId())
+        .orElseThrow(() -> new BusinessException(PlanErrorCode.PLAN_UNIT_NOT_FOUND));
+
+    PlanParticipation participation = planParticipationRepository.findByIdAndPlanUnit(
+            command.participationId(), planUnit)
         .orElseThrow(() -> new BusinessException(PlanErrorCode.PLAN_PARTICIPATION_NOT_FOUND));
 
     participation.withdraw(command.userId());
 
     // 이벤트 발행
-    events.planUnitParticipationQuit(UUID.randomUUID(), command.userId(), command.planUnitId(), command.reason());
+    events.planUnitParticipationQuit(UUID.randomUUID(), command.userId(), planUnit.getId(), command.reason());
 
     return WithdrawPlanUnitParticipationResponse.from(participation);
   }

--- a/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanCommandService.java
@@ -25,7 +25,9 @@ import com.yeoljeong.tripmate.domain.model.PlanUnit;
 import com.yeoljeong.tripmate.domain.repository.PlanUnitRepository;
 import com.yeoljeong.tripmate.event.EventUtils;
 import com.yeoljeong.tripmate.event.PlanUnitConfirmedEvent;
+import com.yeoljeong.tripmate.event.PlanUnitParticipantQuitEvent;
 import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.presentation.dto.response.WithdrawPlanUnitParticipationResponse;
 import java.security.NoSuchAlgorithmException;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -204,6 +206,28 @@ public class PlanCommandService {
 
   }
 
+  /*
+  * 참여 일정 탈퇴
+  * : 참여 상태가 CONFIRMED인 사용자만 가능
+  * */
+  public WithdrawPlanUnitParticipationResponse withdrawPlanUnitParticipant(UUID planId, UUID planUnitId, UUID participationId, UUID userId) {
+
+    PlanParticipation participation = planParticipationRepository.findById(
+            participationId)
+        .orElseThrow(() -> new BusinessException(PlanErrorCode.PLAN_PARTICIPATION_NOT_FOUND));
+
+    participation.withdraw(userId);
+
+    // 이벤트 발행
+    events.planUnitParticipationQuit(new PlanUnitParticipantQuitEvent(
+        UUID.randomUUID(),
+        userId,
+        planUnitId
+    ));
+
+    return WithdrawPlanUnitParticipationResponse.from(participation);
+  }
+
   private void validatePlanUnitHost(PlanUnit planUnit, UUID userId) {
     boolean isHost = planParticipationRepository.existsByPlanUnitAndUserIdAndParticipationRole(planUnit, userId,
         ParticipationRole.HOST);
@@ -282,4 +306,6 @@ public class PlanCommandService {
       }
     }
   }
+
+
 }

--- a/src/main/java/com/yeoljeong/tripmate/domain/exception/PlanErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/exception/PlanErrorCode.java
@@ -66,6 +66,8 @@ public enum PlanErrorCode implements ErrorCode {
   PLAN_PARTICIPATION_STATUS_CHANGE_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 참여 상태 변경입니다."),
   PLAN_UNIT_PARTICIPANT_UPDATE_QUANTITY_INVALID(HttpStatus.BAD_REQUEST, "변경할 참여 인원 수가 올바르지 않습니다."),
   PLAN_PARTICIPATION_STATUS_NOT_APPROVAL(HttpStatus.FORBIDDEN, "호스트 승인 후 참여를 확정할 수 있습니다." ),
+  PLAN_PARTICIPATION_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 탈퇴한 참여자입니다." ),
+  PLAN_PARTICIPATION_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 참여의 사용자만 접근할 수 있습니다."),
 
   PLAN_PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "일정 상품이 존재하지 않습니다.");
 

--- a/src/main/java/com/yeoljeong/tripmate/domain/model/PlanParticipation.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/model/PlanParticipation.java
@@ -121,8 +121,8 @@ public class PlanParticipation extends BaseAuditEntity {
   * */
   public void withdraw(UUID userId) {
     validateOwner(userId);
-    validatePlanParticipationStatus(ParticipationStatus.PAYMENT_CANCELLED);
     validateDeleted();
+    validatePlanParticipationStatus(ParticipationStatus.PAYMENT_CANCELLED);
 
     this.participationStatus = ParticipationStatus.PAYMENT_CANCELLED;
     this.softDelete();

--- a/src/main/java/com/yeoljeong/tripmate/domain/model/PlanParticipation.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/model/PlanParticipation.java
@@ -82,7 +82,7 @@ public class PlanParticipation extends BaseAuditEntity {
       throw new BusinessException(PlanErrorCode.PLAN_PARTICIPATION_STATUS_REQUIRED);
     }
     if (!this.participationStatus.canChangeTo(next)) {
-      throw new BusinessException(PlanErrorCode.PLAN_PARTICIPATION_STATUS_CHANGE_INVALID); // -> 에러코드 메시지 바꾸기
+      throw new BusinessException(PlanErrorCode.PLAN_PARTICIPATION_STATUS_CHANGE_INVALID);
     }
   }
 
@@ -114,6 +114,30 @@ public class PlanParticipation extends BaseAuditEntity {
       throw new BusinessException(PlanErrorCode.PLAN_PARTICIPATION_STATUS_CHANGE_INVALID); // -> 에러코드 메시지 바꾸기
     }
     this.participationStatus = next;
+  }
+
+  /*
+  * 참여 합류된 일정 탈퇴
+  * */
+  public void withdraw(UUID userId) {
+    validateOwner(userId);
+    validatePlanParticipationStatus(ParticipationStatus.PAYMENT_CANCELLED);
+    validateDeleted();
+
+    this.participationStatus = ParticipationStatus.PAYMENT_CANCELLED;
+    this.softDelete();
+  }
+
+  private void validateDeleted() {
+    if (this.isDeleted) {
+      throw new BusinessException(PlanErrorCode.PLAN_PARTICIPATION_ALREADY_DELETED);
+    }
+  }
+
+  private void validateOwner(UUID userId) {
+    if (!this.userId.equals(userId)) {
+      throw new BusinessException(PlanErrorCode.PLAN_PARTICIPATION_FORBIDDEN);
+    }
   }
 
 

--- a/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanParticipationRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanParticipationRepository.java
@@ -29,4 +29,6 @@ public interface PlanParticipationRepository {
   List<PlanParticipation> findAllByPlanUnitIn(List<PlanUnit> planUnit);
 
   int updateStatus(UUID participationId, ParticipationStatus currentStatus, ParticipationStatus nextStatus);
+
+  Optional<PlanParticipation> findById(UUID participationId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanParticipationRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanParticipationRepository.java
@@ -30,5 +30,4 @@ public interface PlanParticipationRepository {
 
   int updateStatus(UUID participationId, ParticipationStatus currentStatus, ParticipationStatus nextStatus);
 
-  Optional<PlanParticipation> findById(UUID participationId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/producer/PlanEventsAdaptor.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/producer/PlanEventsAdaptor.java
@@ -122,10 +122,10 @@ public class PlanEventsAdaptor implements PlanEvents {
 
   /* 참여 합류된 사용자 탈퇴 이벤트*/
   @Override
-  public void planUnitParticipationQuit(UUID eventId, UUID userId, UUID planUnitId) {
+  public void planUnitParticipationQuit(UUID eventId, UUID userId, UUID planUnitId, String reason) {
     try {
       PlanUnitParticipantQuitEvent payload = new PlanUnitParticipantQuitEvent(eventId,
-          userId, planUnitId);
+          userId, planUnitId, reason);
       String json = objectMapper.writeValueAsString(payload);
 
       outBoxRepository.save(

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/producer/PlanEventsAdaptor.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/messaging/producer/PlanEventsAdaptor.java
@@ -7,6 +7,7 @@ import com.yeoljeong.tripmate.event.PlanUnitAddParticipantFailedEvent;
 import com.yeoljeong.tripmate.event.PlanUnitConfirmedEvent;
 import com.yeoljeong.tripmate.event.PlanUnitDeductParticipantEvent;
 import com.yeoljeong.tripmate.event.PlanUnitParticipantAddedEvent;
+import com.yeoljeong.tripmate.event.PlanUnitParticipantQuitEvent;
 import com.yeoljeong.tripmate.event.enums.PlanTopic;
 import com.yeoljeong.tripmate.infrastructer.persistence.PlanOutbox;
 import com.yeoljeong.tripmate.infrastructer.persistence.jpa.PlanOutBoxRepository;
@@ -117,5 +118,27 @@ public class PlanEventsAdaptor implements PlanEvents {
       throw new RuntimeException("이벤트 직렬화 실패", e);
     }
 
+  }
+
+  /* 참여 합류된 사용자 탈퇴 이벤트*/
+  @Override
+  public void planUnitParticipationQuit(UUID eventId, UUID userId, UUID planUnitId) {
+    try {
+      PlanUnitParticipantQuitEvent payload = new PlanUnitParticipantQuitEvent(eventId,
+          userId, planUnitId);
+      String json = objectMapper.writeValueAsString(payload);
+
+      outBoxRepository.save(
+          PlanOutbox.create(PlanTopic.PLAN_UNIT_PARTICIPANT_QUIT_TOPIC, json)
+      );
+    } catch (JsonProcessingException e) {
+      log.error(
+          "[plan-service] 참여 합류된 사용자 탈퇴 이벤트 직렬화 실패: eventId={}, topic={}",
+          eventId,
+          PlanTopic.PLAN_UNIT_PARTICIPANT_QUIT_TOPIC,
+          e
+      );
+      throw new RuntimeException("이벤트 직렬화 실패", e);
+    }
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanParticipationRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanParticipationRepositoryImpl.java
@@ -71,4 +71,9 @@ public class PlanParticipationRepositoryImpl implements PlanParticipationReposit
       ParticipationStatus nextStatus) {
     return jpaRepository.updateStatus(planUnitId, currentStatus, nextStatus);
   }
+
+  @Override
+  public Optional<PlanParticipation> findById(UUID participationId) {
+    return jpaRepository.findById(participationId);
+  }
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanParticipationRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanParticipationRepositoryImpl.java
@@ -72,8 +72,4 @@ public class PlanParticipationRepositoryImpl implements PlanParticipationReposit
     return jpaRepository.updateStatus(planUnitId, currentStatus, nextStatus);
   }
 
-  @Override
-  public Optional<PlanParticipation> findById(UUID participationId) {
-    return jpaRepository.findById(participationId);
-  }
 }

--- a/src/main/java/com/yeoljeong/tripmate/presentation/dto/request/withdrawPlanUnitParticipationRequest.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/dto/request/withdrawPlanUnitParticipationRequest.java
@@ -1,0 +1,9 @@
+package com.yeoljeong.tripmate.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record withdrawPlanUnitParticipationRequest(
+    @NotBlank String reason
+) {
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/presentation/dto/response/WithdrawPlanUnitParticipationResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/dto/response/WithdrawPlanUnitParticipationResponse.java
@@ -1,0 +1,13 @@
+package com.yeoljeong.tripmate.presentation.dto.response;
+
+import com.yeoljeong.tripmate.domain.model.PlanParticipation;
+import java.util.UUID;
+
+public record WithdrawPlanUnitParticipationResponse(
+    UUID planParticipationId
+) {
+
+  public static WithdrawPlanUnitParticipationResponse from(PlanParticipation participation) {
+    return new WithdrawPlanUnitParticipationResponse(participation.getId());
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/presentation/external/PlanController.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/external/PlanController.java
@@ -2,6 +2,7 @@ package com.yeoljeong.tripmate.presentation.external;
 
 import com.yeoljeong.tripmate.application.dto.command.GetPlanCommand;
 import com.yeoljeong.tripmate.application.dto.command.ParticipatePlanCommand;
+import com.yeoljeong.tripmate.application.dto.command.WithdrawPlanUnitParticipationCommand;
 import com.yeoljeong.tripmate.application.dto.result.ConfirmPlanUnitResult;
 import com.yeoljeong.tripmate.application.dto.result.GetPlanDetailResult;
 import com.yeoljeong.tripmate.application.dto.result.ParticipatePlanResult;
@@ -14,6 +15,7 @@ import com.yeoljeong.tripmate.auth.context.UserContext;
 import com.yeoljeong.tripmate.presentation.dto.request.CreatePlanRequest;
 import com.yeoljeong.tripmate.presentation.dto.request.PlanSearchCondition;
 import com.yeoljeong.tripmate.presentation.dto.request.UpdateParticipationStatusRequest;
+import com.yeoljeong.tripmate.presentation.dto.request.withdrawPlanUnitParticipationRequest;
 import com.yeoljeong.tripmate.presentation.dto.response.ConfirmPlanUnitResponse;
 import com.yeoljeong.tripmate.presentation.dto.response.CreatePlanResponse;
 import com.yeoljeong.tripmate.presentation.dto.response.GetPlanDetailResponse;
@@ -109,13 +111,13 @@ public class PlanController {
   @DeleteMapping("/{planId}/unit-plans/{unitPlanId}/participations/{participationId}")
   public ApiResponse<WithdrawPlanUnitParticipationResponse> withdrawPlanUnitParticipant(
       @LoginUser UserContext user,
-      @PathVariable("planId") UUID planId,
       @PathVariable("unitPlanId") UUID planUnitId,
-      @PathVariable("participationId") UUID participationId
+      @PathVariable("participationId") UUID participationId,
+      @Valid @RequestBody withdrawPlanUnitParticipationRequest request
   ) {
 
     WithdrawPlanUnitParticipationResponse response = planCommandService.withdrawPlanUnitParticipant(
-        planId, planUnitId, participationId, user.userId());
+        WithdrawPlanUnitParticipationCommand.from(request,planUnitId, participationId, user.userId()));
 
     return ApiResponse.success(CommonSuccessCode.DELETE,"일정 참여 탈퇴 완료되었습니다.", response);
   }

--- a/src/main/java/com/yeoljeong/tripmate/presentation/external/PlanController.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/external/PlanController.java
@@ -20,6 +20,7 @@ import com.yeoljeong.tripmate.presentation.dto.response.GetPlanDetailResponse;
 import com.yeoljeong.tripmate.presentation.dto.response.ParticipatePlanResponse;
 import com.yeoljeong.tripmate.presentation.dto.response.UpdateParticipationStatusResponse;
 import com.yeoljeong.tripmate.presentation.dto.response.GetPlanResponse;
+import com.yeoljeong.tripmate.presentation.dto.response.WithdrawPlanUnitParticipationResponse;
 import com.yeoljeong.tripmate.response.ApiResponse;
 import com.yeoljeong.tripmate.response.constants.CommonSuccessCode;
 import jakarta.validation.Valid;
@@ -30,6 +31,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -103,6 +105,20 @@ public class PlanController {
     return ApiResponse.success(CommonSuccessCode.OK, "일정이 확정되었습니다.", response);
   }
 
+  // 일정 참여 탈퇴
+  @DeleteMapping("/{planId}/unit-plans/{unitPlanId}/participations/{participationId}")
+  public ApiResponse<WithdrawPlanUnitParticipationResponse> withdrawPlanUnitParticipant(
+      @LoginUser UserContext user,
+      @PathVariable("planId") UUID planId,
+      @PathVariable("unitPlanId") UUID planUnitId,
+      @PathVariable("participationId") UUID participationId
+  ) {
+
+    WithdrawPlanUnitParticipationResponse response = planCommandService.withdrawPlanUnitParticipant(
+        planId, planUnitId, participationId, user.userId());
+
+    return ApiResponse.success(CommonSuccessCode.DELETE,"일정 참여 탈퇴 완료되었습니다.", response);
+  }
   // 일정 상세 조회 (모든 사용자)
   @GetMapping("/{planId}")
   public ApiResponse<GetPlanDetailResponse> getPlanDetail(@PathVariable UUID planId) {

--- a/src/main/java/com/yeoljeong/tripmate/presentation/external/PlanController.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/external/PlanController.java
@@ -111,13 +111,14 @@ public class PlanController {
   @DeleteMapping("/{planId}/unit-plans/{unitPlanId}/participations/{participationId}")
   public ApiResponse<WithdrawPlanUnitParticipationResponse> withdrawPlanUnitParticipant(
       @LoginUser UserContext user,
+      @PathVariable("planId") UUID planId,
       @PathVariable("unitPlanId") UUID planUnitId,
       @PathVariable("participationId") UUID participationId,
       @Valid @RequestBody withdrawPlanUnitParticipationRequest request
   ) {
 
     WithdrawPlanUnitParticipationResponse response = planCommandService.withdrawPlanUnitParticipant(
-        WithdrawPlanUnitParticipationCommand.from(request,planUnitId, participationId, user.userId()));
+        WithdrawPlanUnitParticipationCommand.from(request,planId,planUnitId, participationId, user.userId()));
 
     return ApiResponse.success(CommonSuccessCode.DELETE,"일정 참여 탈퇴 완료되었습니다.", response);
   }


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- close #50 
- 일정 참여 탈퇴 로직 및 이벤트 발행 구현

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- [feat: 참여 일정 탈퇴 로직 구현](https://github.com/10jeong/plan-service/commit/d7f83e3c4f109dc79b247372f051576f650bd5d6)
- [feat: 참여 일정 탈퇴 이벤트 발행 구현](https://github.com/10jeong/plan-service/commit/bed927d7b294f42c41a8042004ab9631a33d6e3c)
- [feat: 참여 일정 탈퇴시, 탈퇴 사유 추가로 dto 및 로직 추가](https://github.com/10jeong/plan-service/pull/53/changes/c18f65e45cd2ed867b406b83c58a188928b9c594)

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
- 일정 참여 탈퇴시, 탈퇴 사유 작성 후 이벤트로 전달


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 플랜 참여에서 탈퇴 기능이 추가되었습니다. 사용자는 탈퇴 시 사유를 입력할 수 있으며, 시스템에서는 중복 탈퇴나 권한 없는 접근에 대한 적절한 검증을 수행합니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/10jeong/plan-service/pull/53)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->