### PR TITLE
[Feat] 결재 완료 이벤트 소비 중 주문 내부 API로 planUnitId 받기

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/application/dto/external/OrderPlanUnitData.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/dto/external/OrderPlanUnitData.java
@@ -1,0 +1,10 @@
+package com.yeoljeong.tripmate.application.dto.external;
+
+import java.util.UUID;
+
+public record OrderPlanUnitData(
+    UUID planUnitId,
+    UUID orderId
+) {
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/application/port/OrderReader.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/port/OrderReader.java
@@ -1,0 +1,10 @@
+package com.yeoljeong.tripmate.application.port;
+
+
+import com.yeoljeong.tripmate.application.dto.external.OrderPlanUnitData;
+import java.util.UUID;
+
+public interface OrderReader {
+
+  OrderPlanUnitData getPlanUnitId(UUID orderId);
+}

--- a/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanInternalCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanInternalCommandService.java
@@ -1,7 +1,9 @@
 package com.yeoljeong.tripmate.application.service.command;
 
 import com.yeoljeong.tripmate.application.dto.command.internal.DeductPlanUnitParticipantCommand;
+import com.yeoljeong.tripmate.application.dto.external.OrderPlanUnitData;
 import com.yeoljeong.tripmate.application.dto.result.FindParticipationStatusResult;
+import com.yeoljeong.tripmate.application.port.OrderReader;
 import com.yeoljeong.tripmate.application.port.PlanEvents;
 import com.yeoljeong.tripmate.domain.enums.ParticipationStatus;
 import com.yeoljeong.tripmate.domain.exception.PlanErrorCode;
@@ -26,6 +28,7 @@ public class PlanInternalCommandService {
   private final PlanParticipationRepository planParticipationRepository;
   private final PlanUnitRepository planUnitRepository;
   private final PlanEvents events;
+  private final OrderReader orderReader;
 
   public FindParticipationStatusResult findParticipationStatusByPlanUnitIdAndUserId(UUID planUnitId, UUID userId) {
 
@@ -89,9 +92,13 @@ public class PlanInternalCommandService {
   * 결제 완료시, 참여 상태 변경 (RESERVED -> CONFIRMED)
   * */
   public void updateParticipantStatus(PaymentCompletedEvent event) {
-    // todo: event에 planUnitId가 들어올때 수정
-    UUID planUnitId = UUID.randomUUID();
-    PlanParticipation participation = planParticipationRepository.findByPlanUnit_IdAndUserId(planUnitId, event.userId())
+
+    OrderPlanUnitData orderPlanUnitData = orderReader.getPlanUnitId(event.orderId());
+    if (orderPlanUnitData == null) {
+      throw new BusinessException(PlanErrorCode.ORDER_PLAN_UNIT_NOT_FOUND);
+    }
+
+    PlanParticipation participation = planParticipationRepository.findByPlanUnit_IdAndUserId(orderPlanUnitData.planUnitId(), event.userId())
         .orElseThrow(() -> new BusinessException(PlanErrorCode.PLAN_PARTICIPATION_NOT_FOUND));
 
     participation.validatePlanParticipationStatus(ParticipationStatus.CONFIRMED);

--- a/src/main/java/com/yeoljeong/tripmate/domain/exception/PlanErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/exception/PlanErrorCode.java
@@ -69,7 +69,8 @@ public enum PlanErrorCode implements ErrorCode {
   PLAN_PARTICIPATION_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 탈퇴한 참여자입니다." ),
   PLAN_PARTICIPATION_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 참여의 사용자만 접근할 수 있습니다."),
 
-  PLAN_PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "일정 상품이 존재하지 않습니다.");
+  PLAN_PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "일정 상품이 존재하지 않습니다."),
+  ORDER_PLAN_UNIT_NOT_FOUND(HttpStatus.NOT_FOUND, "주문에 대한 일정 정보을 찾을 수 없습니다.");
 
 
   private final HttpStatus status;

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/external/order/OrderFeignClient.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/external/order/OrderFeignClient.java
@@ -1,0 +1,14 @@
+package com.yeoljeong.tripmate.infrastructer.external.order;
+
+import com.yeoljeong.tripmate.application.dto.external.OrderPlanUnitData;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "order-service")
+public interface OrderFeignClient {
+
+  @GetMapping("internal/orders/{orderId}")
+  OrderPlanUnitData getPlanUnitId(@PathVariable("orderId") UUID orderId);
+}

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/external/order/OrderReaderImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/external/order/OrderReaderImpl.java
@@ -1,0 +1,19 @@
+package com.yeoljeong.tripmate.infrastructer.external.order;
+
+import com.yeoljeong.tripmate.application.dto.external.OrderPlanUnitData;
+import com.yeoljeong.tripmate.application.port.OrderReader;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrderReaderImpl implements OrderReader {
+
+  private final OrderFeignClient orderFeignClient;
+
+  @Override
+  public OrderPlanUnitData getPlanUnitId(UUID orderId) {
+    return orderFeignClient.getPlanUnitId(orderId);
+  }
+}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- close #49 

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- [feat: 주문에 대한 planUnitId feignClient로 조회 추가](https://github.com/10jeong/plan-service/commit/36f675f2b290c0805f82816019ec21abf56c8011)

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
-
