### PR TITLE
[Feat] 참여 상태가 RESERVED, CONFIRMED인 일정의 OPEN 여부확인 내부 API 구현

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/application/service/query/PlanInternalQueryService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/query/PlanInternalQueryService.java
@@ -1,0 +1,20 @@
+package com.yeoljeong.tripmate.application.service.query;
+
+import com.yeoljeong.tripmate.domain.repository.PlanParticipationRepository;
+import com.yeoljeong.tripmate.presentation.dto.response.UserHasOpenPlanResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PlanInternalQueryService {
+
+  private final PlanParticipationRepository planParticipationRepository;
+
+  /* 참여중인 일정 중 OPEN이 존재하는지 확인 (회원 내부 API)*/
+  public UserHasOpenPlanResponse hasOpenPlan(UUID userId) {
+    boolean existsOpenPlan =  planParticipationRepository.existsOpenPlan(userId);
+    return UserHasOpenPlanResponse.from(existsOpenPlan);
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanParticipationRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanParticipationRepository.java
@@ -30,4 +30,5 @@ public interface PlanParticipationRepository {
 
   int updateStatus(UUID participationId, ParticipationStatus currentStatus, ParticipationStatus nextStatus);
 
+  boolean existsOpenPlan(UUID userId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/jpa/PlanParticipationJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/jpa/PlanParticipationJpaRepository.java
@@ -39,4 +39,18 @@ public interface PlanParticipationJpaRepository extends JpaRepository<PlanPartic
       @Param("participationId") UUID participationId,
       @Param("currentStatus") ParticipationStatus currentStatus,
       @Param("nextStatus") ParticipationStatus nextStatus);
+
+  @Query("""
+    select count(pa) > 0
+      from PlanParticipation pa
+        join pa.planUnit u 
+        join u.plan p
+          where pa.userId = :userId
+            and pa.participationStatus in (
+              com.yeoljeong.tripmate.domain.enums.ParticipationStatus.RESERVED,
+              com.yeoljeong.tripmate.domain.enums.ParticipationStatus.CONFIRMED
+              )
+            and p.recruitStatus = com.yeoljeong.tripmate.domain.enums.RecruitStatus.OPEN
+  """)
+  boolean existsOpenPlan(@Param("userId") UUID userId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanParticipationRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanParticipationRepositoryImpl.java
@@ -72,4 +72,8 @@ public class PlanParticipationRepositoryImpl implements PlanParticipationReposit
     return jpaRepository.updateStatus(planUnitId, currentStatus, nextStatus);
   }
 
+  @Override
+  public boolean existsOpenPlan(UUID userId) {
+    return jpaRepository.existsOpenPlan(userId);
+  }
 }

--- a/src/main/java/com/yeoljeong/tripmate/presentation/dto/response/UserHasOpenPlanResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/dto/response/UserHasOpenPlanResponse.java
@@ -1,0 +1,10 @@
+package com.yeoljeong.tripmate.presentation.dto.response;
+
+public record UserHasOpenPlanResponse(
+    boolean hasActiveData
+) {
+
+  public static UserHasOpenPlanResponse from(boolean existsOpenPlan) {
+    return new UserHasOpenPlanResponse(existsOpenPlan);
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/presentation/internal/PlanInternalController.java
+++ b/src/main/java/com/yeoljeong/tripmate/presentation/internal/PlanInternalController.java
@@ -1,13 +1,16 @@
 package com.yeoljeong.tripmate.presentation.internal;
 
 import com.yeoljeong.tripmate.application.dto.result.FindParticipationStatusResult;
+import com.yeoljeong.tripmate.application.service.query.PlanInternalQueryService;
 import com.yeoljeong.tripmate.application.service.command.PlanInternalCommandService;
 import com.yeoljeong.tripmate.presentation.dto.response.FindParticipationStatusResponse;
+import com.yeoljeong.tripmate.presentation.dto.response.UserHasOpenPlanResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PlanInternalController {
 
   private final PlanInternalCommandService planInternalCommandService;
+  private final PlanInternalQueryService planInternalQueryService;
 
   @GetMapping("/plan-units/{planUnitId}/participations/users/{userId}")
   public FindParticipationStatusResponse findParticipationStatus(
@@ -27,6 +31,14 @@ public class PlanInternalController {
     FindParticipationStatusResponse response = FindParticipationStatusResponse.from(result);
 
     return response;
+  }
+
+  /* 참여중인 일정 중 OPEN이 존재하는지 확인 (회원 내부 API)*/
+  @GetMapping("/plan/withdrawal-check")
+  public UserHasOpenPlanResponse hasOpenPlan(
+      @RequestParam("userId") UUID userId
+  ) {
+    return planInternalQueryService.hasOpenPlan(userId);
   }
 
 }


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- close #55 

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- dto, controller, service, repository 생성
- 

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자의 활성 계획 존재 여부를 확인하는 새로운 내부 API 엔드포인트 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/10jeong/plan-service/pull/56)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->