### PR TITLE
[Fix] 누락된 검증 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.yeoljeong:common-module:1.0.2-SNAPSHOT'
+    implementation 'com.yeoljeong:common-module:1.0.4-SNAPSHOT'
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -47,6 +47,8 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 }
 dependencyManagement {
     imports {

--- a/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanCommandService.java
@@ -240,7 +240,7 @@ public class PlanCommandService {
 
 
   private void validateDuplicateParticipation(UUID planUnitId, UUID guestId) {
-    if (planParticipationRepository.existsByPlanUnitIdAndUserId(planUnitId, guestId)) {
+    if (planParticipationRepository.existsByPlanUnitIdAndUserIdAndIsDeletedIsFalse(planUnitId, guestId)) {
       throw new BusinessException(PlanErrorCode.PLAN_PARTICIPATION_ALREADY_EXISTS);
     }
   }

--- a/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/application/service/command/PlanCommandService.java
@@ -114,6 +114,7 @@ public class PlanCommandService {
 
     // 중복 참여 검증
     validateDuplicateParticipation(command.planUnitId(),command.guestId());
+    // 모집 가능한 인원인지(최대 참여 인원 초과 여부) 검증
     try {
       PlanParticipation participation = PlanParticipation.createGuest(command.guestId(), planUnit);
       PlanParticipation savedParticipation = planParticipationRepository.save(participation);

--- a/src/main/java/com/yeoljeong/tripmate/domain/exception/PlanErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/exception/PlanErrorCode.java
@@ -67,14 +67,15 @@ public enum PlanErrorCode implements ErrorCode {
   PLAN_PARTICIPATION_PLAN_UNIT_MISMATCH(HttpStatus.BAD_REQUEST, "해당 단위 일정 정보는 요청한 단위 일정과 일치하지 않습니다."),
   PLAN_PARTICIPATION_STATUS_CHANGE_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 참여 상태 변경입니다."),
   PLAN_UNIT_PARTICIPANT_UPDATE_QUANTITY_INVALID(HttpStatus.BAD_REQUEST, "변경할 참여 인원 수가 올바르지 않습니다."),
-  PLAN_PARTICIPATION_STATUS_NOT_APPROVAL(HttpStatus.FORBIDDEN, "호스트 승인 후 참여를 확정할 수 있습니다." ),
+  PLAN_PARTICIPATION_STATUS_NOT_APPROVED(HttpStatus.FORBIDDEN, "호스트 승인 후 참여를 확정할 수 있습니다." ),
   PLAN_PARTICIPATION_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 탈퇴한 참여자입니다." ),
   PLAN_PARTICIPATION_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 참여의 사용자만 접근할 수 있습니다."),
   PLAN_RECRUIT_CLOSED(HttpStatus.BAD_REQUEST, "현재 모집 중인 일정만 참여할 수 있습니다." ),
+  PLAN_PARTICIPATION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "최대 참여 인원을 초과하여 신청이 불가합니다."),
+
 
   PLAN_PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "일정 상품이 존재하지 않습니다."),
   ORDER_PLAN_UNIT_NOT_FOUND(HttpStatus.NOT_FOUND, "주문에 대한 일정 정보을 찾을 수 없습니다.");
-
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/yeoljeong/tripmate/domain/exception/PlanErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/exception/PlanErrorCode.java
@@ -39,6 +39,7 @@ public enum PlanErrorCode implements ErrorCode {
   PLAN_UNIT_NOT_HOST(HttpStatus.FORBIDDEN, "해당 단위 일정의 호스트만 접근가능합니다."),
   PLAN_UNIT_ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, "이미 확정된 일정입니다."),
   PLAN_UNIT_CONFIRMED_QUIT_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "확정된 일정은 탈퇴할 수 없습니다."),
+  PLAN_UNIT_CONFIRMED_PARTICIPATION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "확정된 일정에는 새로 참여 신청할 수 없습니다." ),
 
 
   // plan_product_snapshot

--- a/src/main/java/com/yeoljeong/tripmate/domain/exception/PlanErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/exception/PlanErrorCode.java
@@ -70,6 +70,7 @@ public enum PlanErrorCode implements ErrorCode {
   PLAN_PARTICIPATION_STATUS_NOT_APPROVAL(HttpStatus.FORBIDDEN, "호스트 승인 후 참여를 확정할 수 있습니다." ),
   PLAN_PARTICIPATION_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 탈퇴한 참여자입니다." ),
   PLAN_PARTICIPATION_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 참여의 사용자만 접근할 수 있습니다."),
+  PLAN_RECRUIT_CLOSED(HttpStatus.BAD_REQUEST, "현재 모집 중인 일정만 참여할 수 있습니다." ),
 
   PLAN_PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "일정 상품이 존재하지 않습니다."),
   ORDER_PLAN_UNIT_NOT_FOUND(HttpStatus.NOT_FOUND, "주문에 대한 일정 정보을 찾을 수 없습니다.");

--- a/src/main/java/com/yeoljeong/tripmate/domain/exception/PlanErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/exception/PlanErrorCode.java
@@ -38,6 +38,7 @@ public enum PlanErrorCode implements ErrorCode {
   PLAN_UNIT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 단위 일정입니다."),
   PLAN_UNIT_NOT_HOST(HttpStatus.FORBIDDEN, "해당 단위 일정의 호스트만 접근가능합니다."),
   PLAN_UNIT_ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, "이미 확정된 일정입니다."),
+  PLAN_UNIT_CONFIRMED_QUIT_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "확정된 일정은 탈퇴할 수 없습니다."),
 
 
   // plan_product_snapshot

--- a/src/main/java/com/yeoljeong/tripmate/domain/model/PlanParticipation.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/model/PlanParticipation.java
@@ -22,7 +22,6 @@ import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.ValidateException;
 
 @Entity
 @Table(
@@ -63,6 +62,7 @@ public class PlanParticipation extends BaseAuditEntity {
   public static PlanParticipation createGuest(UUID userId, PlanUnit planUnit) {
     validateStatusOpen(planUnit); // 모집 상태 OPEN 여부 검증
     validateNotConfirmed(planUnit); // 모집 상태 확정여부 검증
+    validateParticipantLimit(planUnit); // 최대 참여 인원 초과 여부 검증
     return new PlanParticipation(userId, ParticipationRole.GUEST, ParticipationStatus.REQUESTED, planUnit);
   }
 
@@ -76,6 +76,16 @@ public class PlanParticipation extends BaseAuditEntity {
     this.participationRole = participationRole;
     this.participationStatus = participationStatus;
     this.planUnit = planUnit;
+  }
+
+  /*
+   * 최대 참여 인원 초과 여부 검증
+   * */
+  private static void validateParticipantLimit(PlanUnit planUnit) {
+    if (planUnit.getParticipantCount().getMaxCount()
+        < planUnit.getParticipantCount().getCurrentCount() + 1) {
+      throw new BusinessException(PlanErrorCode.PLAN_PARTICIPATION_LIMIT_EXCEEDED);
+    }
   }
 
   /*

--- a/src/main/java/com/yeoljeong/tripmate/domain/model/PlanParticipation.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/model/PlanParticipation.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.ValidateException;
 
 @Entity
 @Table(
@@ -59,6 +60,7 @@ public class PlanParticipation extends BaseAuditEntity {
   }
 
   public static PlanParticipation createGuest(UUID userId, PlanUnit planUnit) {
+    validateNotConfirmed(planUnit);
     return new PlanParticipation(userId, ParticipationRole.GUEST, ParticipationStatus.REQUESTED, planUnit);
   }
 
@@ -72,6 +74,15 @@ public class PlanParticipation extends BaseAuditEntity {
     this.participationRole = participationRole;
     this.participationStatus = participationStatus;
     this.planUnit = planUnit;
+  }
+
+  /*
+  * 확정된 일정 참여 불가 검증
+  * */
+  private static void validateNotConfirmed(PlanUnit planUnit) {
+    if (planUnit.isConfirmed()) {
+      throw new BusinessException(PlanErrorCode.PLAN_UNIT_CONFIRMED_PARTICIPATION_NOT_ALLOWED);
+    }
   }
 
   /*

--- a/src/main/java/com/yeoljeong/tripmate/domain/model/PlanParticipation.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/model/PlanParticipation.java
@@ -119,10 +119,17 @@ public class PlanParticipation extends BaseAuditEntity {
   public void withdraw(UUID userId) {
     validateOwner(userId);
     validateDeleted();
+    validatePlanUnitNotConfirmed();
     validatePlanParticipationStatus(ParticipationStatus.PAYMENT_CANCELLED);
 
     this.participationStatus = ParticipationStatus.PAYMENT_CANCELLED;
     this.softDelete();
+  }
+
+  private void validatePlanUnitNotConfirmed() {
+    if (this.planUnit.isConfirmed()) {
+      throw new BusinessException(PlanErrorCode.PLAN_UNIT_CONFIRMED_QUIT_NOT_ALLOWED);
+    }
   }
 
   private void validateDeleted() {

--- a/src/main/java/com/yeoljeong/tripmate/domain/model/PlanParticipation.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/model/PlanParticipation.java
@@ -24,14 +24,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(
-    name = "p_plan_participation",
-    uniqueConstraints = {
-        @UniqueConstraint(
-            name = "uk_plan_particiation_user_plan_unit",
-            columnNames = {"user_id", "plan_unit_id"}
-        )
-    })
+@Table(name = "p_plan_participation")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class PlanParticipation extends BaseAuditEntity {

--- a/src/main/java/com/yeoljeong/tripmate/domain/model/PlanParticipation.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/model/PlanParticipation.java
@@ -116,23 +116,6 @@ public class PlanParticipation extends BaseAuditEntity {
   }
 
   /*
-   * 주문 생성시, 참여 상태 검증
-   * */
-  public void validateApprovalStatus() {
-    if (this.participationStatus != ParticipationStatus.APPROVED) {
-      throw new BusinessException(PlanErrorCode.PLAN_PARTICIPATION_STATUS_NOT_APPROVAL);
-    }
-  }
-
-  /*
-  * 주문 생성시, 참여 상태(APPROVED -> RESERVED)
-  * */
-  public void confirmParticipation() {
-    validateApprovalStatus();
-    this.participationStatus = ParticipationStatus.RESERVED;
-  }
-
-  /*
   * 일정 참여상태 변경
   * */
   public void changeStatus(ParticipationStatus next) {

--- a/src/main/java/com/yeoljeong/tripmate/domain/model/PlanParticipation.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/model/PlanParticipation.java
@@ -1,6 +1,7 @@
 package com.yeoljeong.tripmate.domain.model;
 
 import com.yeoljeong.tripmate.domain.BaseAuditEntity;
+import com.yeoljeong.tripmate.domain.enums.RecruitStatus;
 import com.yeoljeong.tripmate.domain.exception.PlanErrorCode;
 import com.yeoljeong.tripmate.domain.enums.ParticipationRole;
 import com.yeoljeong.tripmate.domain.enums.ParticipationStatus;
@@ -60,7 +61,8 @@ public class PlanParticipation extends BaseAuditEntity {
   }
 
   public static PlanParticipation createGuest(UUID userId, PlanUnit planUnit) {
-    validateNotConfirmed(planUnit);
+    validateStatusOpen(planUnit); // 모집 상태 OPEN 여부 검증
+    validateNotConfirmed(planUnit); // 모집 상태 확정여부 검증
     return new PlanParticipation(userId, ParticipationRole.GUEST, ParticipationStatus.REQUESTED, planUnit);
   }
 
@@ -74,6 +76,15 @@ public class PlanParticipation extends BaseAuditEntity {
     this.participationRole = participationRole;
     this.participationStatus = participationStatus;
     this.planUnit = planUnit;
+  }
+
+  /*
+   * 모집 상태 OPEN 여부 검증
+   * */
+  private static void validateStatusOpen(PlanUnit planUnit) {
+    if (!planUnit.getPlan().getRecruitStatus().equals(RecruitStatus.OPEN)) {
+      throw new BusinessException(PlanErrorCode.PLAN_RECRUIT_CLOSED);
+    }
   }
 
   /*

--- a/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanParticipationRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/repository/PlanParticipationRepository.java
@@ -14,7 +14,7 @@ public interface PlanParticipationRepository {
 
   PlanParticipation save(PlanParticipation participation);
 
-  boolean existsByPlanUnitIdAndUserId(UUID planUnitId, UUID guestId);
+  boolean existsByPlanUnitIdAndUserIdAndIsDeletedIsFalse(UUID planUnitId, UUID guestId);
 
   Optional<PlanParticipation> findByPlanUnitAndUserId(PlanUnit planUnit, UUID uuid);
 

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/jpa/PlanParticipationJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/jpa/PlanParticipationJpaRepository.java
@@ -14,7 +14,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface PlanParticipationJpaRepository extends JpaRepository<PlanParticipation, UUID> {
 
-  boolean existsByPlanUnitIdAndUserId(UUID planUnitId, UUID guestId);
+  boolean existsByPlanUnitIdAndUserIdAndIsDeletedIsFalse(UUID planUnitId, UUID guestId);
 
   Optional<PlanParticipation> findByPlanUnitAndUserId(PlanUnit planUnit, UUID userId);
 

--- a/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanParticipationRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/infrastructer/persistence/repository/PlanParticipationRepositoryImpl.java
@@ -29,8 +29,8 @@ public class PlanParticipationRepositoryImpl implements PlanParticipationReposit
   }
 
   @Override
-  public boolean existsByPlanUnitIdAndUserId(UUID planUnitId, UUID guestId) {
-    return jpaRepository.existsByPlanUnitIdAndUserId(planUnitId, guestId);
+  public boolean existsByPlanUnitIdAndUserIdAndIsDeletedIsFalse(UUID planUnitId, UUID guestId) {
+    return jpaRepository.existsByPlanUnitIdAndUserIdAndIsDeletedIsFalse(planUnitId, guestId);
   }
 
   @Override

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -79,3 +79,10 @@ management:
       show-details: always
     prometheus:
       access: unrestricted
+  tracing:
+    sampling:
+      probability: 1.0
+
+  zipkin:
+    tracing:
+      endpoint: ${ZIPKIN_SERVER_URL}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- close #79 
- close #81 
-  누락된 검증 로직 구현

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- [x]  게스트 참여 신청
    - [x]  참여 상태값 변경으로 인한 문제 해결
        - [x]  해당 일정의 참여했지만 상태가 결제취소(`PAYMENT_CANCELLED`), 주문취소(`RESERVED_CANCELLED`)한 사용자는 softDelete 처리가되었으므로 **다시 참여 신청이 가능하도록 수정**
    - [x]  모집이 종료된 일정에는 참여 신청할 수 없도록 수정
    - [x]  최대 참여 인원을 초과하여 참여 신청할 수 없도록 수정
    - [x]  단위 일정 확정시, 참여 신청 못하도록 수정
- [x]  단위 일정 참여 합류 탈퇴
    - [x]  일정이 확정된 이후에는 탈퇴할 수 없도록 수정

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 플랜 모집 인원 제한 검증 추가
  * 삭제된 참가 기록은 제외하고 재참가 가능

* **개선 사항**
  * 플랜 참가 시 모집 상태 확인 강화
  * 확정된 플랜에 대한 참가 및 탈퇴 제한 추가
  * 더 정확한 에러 메시지 제공

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/10jeong/plan-service/pull/80)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->